### PR TITLE
feat - FactoryBot list support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for testing array responses via `json`
 - Added check to block RSpec overwrites from running with internal tests
 - Added debugging access to `expected_json_class` variable.
+- Added support for FactoryBot list strategies through the new `size` attribute
+  ```yaml
+  variables:
+    users:
+      factory.user:
+        size: 10  # Creates 10 user records
+  ```
+  - All FactoryBot list methods now supported:
+    - `create_list` (default)
+    - `build_list`
+    - `build_stubbed_list`
+    - `attributes_for_list`
+    - `build_pair`
+    - `create_pair`
+  - Comprehensive documentation available in the [Factory Lists wiki](https://github.com/itsthedevman/spec_forge/wiki/Factory-Lists)
 
 ### Changed
 

--- a/lib/spec_forge/attribute.rb
+++ b/lib/spec_forge/attribute.rb
@@ -18,6 +18,8 @@ require_relative "attribute/variable"
 
 module SpecForge
   class Attribute
+    include Resolvable
+
     #
     # Binds variables to Attribute objects
     #
@@ -191,9 +193,9 @@ module SpecForge
     def __resolve(value)
       case value
       when ArrayLike
-        value.map(&:resolve)
+        value.map(&resolvable_proc)
       when HashLike
-        value.transform_values(&:resolve)
+        value.transform_values(&resolvable_proc)
       else
         value
       end

--- a/lib/spec_forge/attribute/factory.rb
+++ b/lib/spec_forge/attribute/factory.rb
@@ -7,11 +7,27 @@ module SpecForge
 
       KEYWORD_REGEX = /^factories\./i
 
-      BUILD_STRATEGIES = %w[
+      # These are the base strategies that can be provided either with or without size
+      # stubbed will be transformed into build_stubbed
+      BASE_STRATEGIES = %w[
         build
         create
-        attributes_for
         build_stubbed
+        attributes_for
+      ].freeze
+
+      # All available build strategies that are accepted
+      BUILD_STRATEGIES = %w[
+        attributes_for
+        attributes_for_list
+        build
+        build_list
+        build_pair
+        build_stubbed
+        build_stubbed_list
+        create
+        create_list
+        create_pair
       ].freeze
 
       alias_method :factory_name, :header
@@ -34,17 +50,53 @@ module SpecForge
 
       def base_object
         attributes = arguments[:keyword]
+
+        # Default functionality is to create ("factory.user")
         return FactoryBot.create(factory_name) if attributes.blank?
 
-        # Determine build strat
-        build_strategy = attributes[:build_strategy].resolve_value
+        build_arguments = construct_factory_parameters(attributes)
+        FactoryBot.public_send(*build_arguments)
+      end
+
+      def construct_factory_parameters(attributes)
+        build_strategy, list_size = determine_build_strategy(attributes)
+
+        # This is set up for the base strategies + _pair
+        # FactoryBot.create(factory_name, **attributes)
+        build_arguments = [
+          build_strategy,
+          factory_name,
+          **attributes[:attributes].resolve_value
+        ]
+
+        # Insert the list size after the strategy
+        # FactoryBot.create_list(factory_name, list_size, **attributes)
+        if build_strategy.end_with?("_list")
+          build_arguments.insert(2, list_size)
+        end
+
+        build_arguments
+      end
+
+      def determine_build_strategy(attributes)
+        # Determine build strat, and unfreeze
+        build_strategy = +attributes[:build_strategy].resolve_value
+        list_size = attributes[:size].resolve_value
 
         # stubbed => build_stubbed
-        build_strategy.prepend("build_") if build_strategy == "stubbed"
+        build_strategy.prepend("build_") if build_strategy.start_with?("stubbed")
+
+        # create + size => create_list
+        # build + size => build_list
+        # build_stubbed + size => build_stubbed_list
+        # attributes_for + size => attributes_for_list
+        if list_size.positive? && BASE_STRATEGIES.include?(build_strategy)
+          build_strategy += "_list"
+        end
+
         raise InvalidBuildStrategy, build_strategy unless BUILD_STRATEGIES.include?(build_strategy)
 
-        attributes = attributes[:attributes].resolve_value
-        FactoryBot.public_send(build_strategy, factory_name, **attributes)
+        [build_strategy, list_size]
       end
     end
   end

--- a/lib/spec_forge/normalizer/factory_reference.rb
+++ b/lib/spec_forge/normalizer/factory_reference.rb
@@ -12,6 +12,11 @@ module SpecForge
           type: String,
           aliases: %i[strategy],
           default: "create"
+        },
+        size: {
+          type: Integer,
+          aliases: %i[count],
+          default: 0
         }
       }.freeze
     end

--- a/spec/integration/spec_forge/specs/users.yml
+++ b/spec/integration/spec_forge/specs/users.yml
@@ -2,8 +2,8 @@ index_users:
   url: /users
   variables:
     users:
-    - factories.user
-    - factories.user
+      factories.user:
+        size: 2
   expectations:
   - variables:
       first_user: variables.users.first

--- a/spec/lib/spec_forge/normalizer/factory_reference_spec.rb
+++ b/spec/lib/spec_forge/normalizer/factory_reference_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe SpecForge::Normalizer do
         build_strategy: "create",
         attributes: {
           name: "faker.name.name"
-        }
+        },
+        size: 1
       }
     end
 
@@ -65,14 +66,39 @@ RSpec.describe SpecForge::Normalizer do
       end
     end
 
+    context "when 'size' is nil" do
+      before do
+        factory[:size] = nil
+      end
+
+      it do
+        expect(normalized[:size]).to eq(0)
+      end
+    end
+
+    context "when 'size' is not an Integer" do
+      before do
+        factory[:size] = 1.0
+      end
+
+      it do
+        expect { normalized }.to raise_error(
+          SpecForge::InvalidStructureError,
+          "Expected Integer, got Float for \"size\" on factory reference"
+        )
+      end
+    end
+
     context "when aliases are used" do
       before do
         factory[:build_strategy] = "build"
         factory[:strategy] = factory.delete(:build_strategy)
+        factory[:count] = factory.delete(:size)
       end
 
       it do
         expect(normalized[:build_strategy]).to eq(factory[:strategy])
+        expect(normalized[:size]).to eq(factory[:count])
       end
     end
   end


### PR DESCRIPTION
Added support for FactoryBot list strategies through the new `size` attribute
```yaml
variables:
  users:
    factory.user:
      size: 10  # Creates 10 user records
```

All FactoryBot list methods now supported:
  - `create_list` (default)
  - `build_list`
  - `build_stubbed_list`
  - `attributes_for_list`
  - `build_pair`
  - `create_pair`
  
  Wiki entry will be added once merged