### PR TITLE
feat - Add support for referencing global variables

### DIFF
--- a/lib/spec_forge/attribute.rb
+++ b/lib/spec_forge/attribute.rb
@@ -79,6 +79,8 @@ module SpecForge
     #
     def self.from_string(string)
       case string
+      when Global::KEYWORD_REGEX
+        Global.new(string)
       when Faker::KEYWORD_REGEX
         Faker.new(string)
       when Variable::KEYWORD_REGEX

--- a/lib/spec_forge/attribute.rb
+++ b/lib/spec_forge/attribute.rb
@@ -5,17 +5,6 @@ require_relative "attribute/parameterized"
 require_relative "attribute/chainable"
 require_relative "attribute/resolvable"
 
-# Doesn't matter
-require_relative "attribute/factory"
-require_relative "attribute/faker"
-require_relative "attribute/literal"
-require_relative "attribute/matcher"
-require_relative "attribute/regex"
-require_relative "attribute/resolvable_array"
-require_relative "attribute/resolvable_hash"
-require_relative "attribute/transform"
-require_relative "attribute/variable"
-
 module SpecForge
   #
   # Base class for all attribute types in SpecForge.
@@ -253,3 +242,15 @@ module SpecForge
     end
   end
 end
+
+# Order doesn't matter
+require_relative "attribute/factory"
+require_relative "attribute/faker"
+require_relative "attribute/global"
+require_relative "attribute/literal"
+require_relative "attribute/matcher"
+require_relative "attribute/regex"
+require_relative "attribute/resolvable_array"
+require_relative "attribute/resolvable_hash"
+require_relative "attribute/transform"
+require_relative "attribute/variable"

--- a/lib/spec_forge/attribute/global.rb
+++ b/lib/spec_forge/attribute/global.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module SpecForge
+  class Attribute
+    #
+    # Represents an attribute that references values from the global context
+    #
+    # This class allows accessing shared data defined at the global level through
+    # namespaced references. It provides access to global variables that are shared
+    # across all specs in a file, enabling consistent test data without repetition.
+    #
+    # Currently supports the "variables" namespace.
+    #
+    # @example Basic usage in YAML
+    #   # Reference a global variable in a spec
+    #   session_token: global.variables.session_token
+    #
+    #   # Using within a request body
+    #   body:
+    #     api_version: global.variables.api_version
+    #     auth_token: global.variables.auth_token
+    #
+    class Global < Attribute
+      #
+      # Regular expression pattern that matches attribute keywords with this prefix
+      # Used for identifying this attribute type during parsing
+      #
+      # @return [Regexp]
+      #
+      KEYWORD_REGEX = /^global\./i
+
+      #
+      # The underlying attribute that will be resolved
+      # For variables, this will be a Variable attribute instance
+      #
+      # @return [Attribute] The wrapped attribute instance
+      #
+      attr_reader :value
+
+      #
+      # Creates a new global attribute from the input string
+      #
+      # Parses the input string to extract the namespace and path,
+      # then creates the appropriate attribute type to handle the resolution.
+      #
+      # @raise [InvalidGlobalNamespaceError] If an unsupported namespace is referenced
+      #
+      def initialize(...)
+        super
+
+        # Skip the "global" prefix
+        components = input.split(".")[1..]
+        namespace = components.first
+
+        global_context = SpecForge.context.global
+
+        @value =
+          case namespace
+          when "variables"
+            variable_input = components.join(".")
+            variable = Attribute::Variable.new(variable_input)
+            variable.bind_variables(global_context.variables.to_h)
+            variable
+          else
+            raise InvalidGlobalNamespaceError, namespace
+          end
+      end
+
+      #
+      # Resolves the global reference to its actual value
+      #
+      # Delegates resolution to the underlying attribute and caches the result
+      #
+      # @return [Object] The fully resolved value from the global context
+      #
+      def resolve
+        @resolved ||= @value.resolve
+      end
+    end
+  end
+end

--- a/lib/spec_forge/error.rb
+++ b/lib/spec_forge/error.rb
@@ -216,4 +216,13 @@ module SpecForge
       super(message)
     end
   end
+
+  #
+  # Raised when the provided namespace is not defined on the global context
+  #
+  class InvalidGlobalNamespaceError < Error
+    def initialize(provided_namespace)
+      super("Invalid global namespace #{provided_namespace.in_quotes}. Currently supported namespaces are: \"variables\"")
+    end
+  end
 end

--- a/lib/spec_forge/normalizer/constraint.rb
+++ b/lib/spec_forge/normalizer/constraint.rb
@@ -21,7 +21,7 @@ module SpecForge
       #
       STRUCTURE = {
         status: {
-          type: Integer
+          type: [Integer, String]
         },
         json: {
           type: [Hash, Array],

--- a/lib/spec_forge/spec/expectation/constraint.rb
+++ b/lib/spec_forge/spec/expectation/constraint.rb
@@ -19,7 +19,7 @@ module SpecForge
         #
         # Creates a new constraint
         #
-        # @param status [Integer] The expected HTTP status code
+        # @param status [Integer, String] The expected HTTP status code, or reference to one
         # @param json [Hash, Array] The expected JSON with matchers
         #
         # @return [Constraint] A new constraint instance

--- a/spec/integration/spec_forge/specs/users.yml
+++ b/spec/integration/spec_forge/specs/users.yml
@@ -1,3 +1,7 @@
+global:
+  variables:
+    status_ok: 200
+
 index_users:
   url: /users
   variables:
@@ -9,7 +13,7 @@ index_users:
       first_user: variables.users.first
       second_user: variables.users.second
     expect:
-      status: 200
+      status: global.variables.status_ok
       json:
         users:
         - active: true
@@ -32,7 +36,7 @@ show_user:
     query:
       id: variables.user.id
     expect:
-      status: 200
+      status: global.variables.status_ok
       json:
         user:
           name: variables.user.name
@@ -52,7 +56,7 @@ create_user:
       name: variables.name
       email: variables.email
     expect:
-      status: 200
+      status: global.variables.status_ok
       json:
         user:
           name: variables.name
@@ -70,7 +74,7 @@ update_user:
   - body:
       role: admin
     expect:
-      status: 200
+      status: global.variables.status_ok
       json:
         user:
           name: variables.user.name
@@ -86,7 +90,7 @@ destroy_user:
     id: variables.users.first.id
   expectations:
   - expect:
-      status: 200
+      status: global.variables.status_ok
       json:
         user:
           name: variables.users.first.name

--- a/spec/lib/spec_forge/attribute/factory_spec.rb
+++ b/spec/lib/spec_forge/attribute/factory_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe SpecForge::Attribute::Factory do
     SpecForge::Factory.new(name: :user, model_class: "User", attributes: {name: "Bob"}).register
   end
 
+  include_examples "from_input_to_attribute" do
+    let(:input) { "factories.user" }
+  end
+
   context "when just the factory name is referenced" do
     it "is expected to load the factory" do
       expect(factory.factory_name).to eq(:user)

--- a/spec/lib/spec_forge/attribute/faker_spec.rb
+++ b/spec/lib/spec_forge/attribute/faker_spec.rb
@@ -1,14 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe SpecForge::Attribute::Faker do
-  let(:path) { "" }
+  let(:input) { "" }
   let(:positional) { [] }
   let(:keyword) { {} }
 
-  subject(:attribute) { described_class.new(path, positional, keyword) }
+  subject(:attribute) { described_class.new(input, positional, keyword) }
 
-  context "when the faker path is valid" do
-    let(:path) { "faker.number.positive" }
+  include_examples "from_input_to_attribute" do
+    let(:input) { "faker.string.random" }
+  end
+
+  context "when the faker input is valid" do
+    let(:input) { "faker.number.positive" }
 
     it "parses the faker class and method" do
       expect(attribute.faker_class).to eq(Faker::Number)
@@ -16,8 +20,8 @@ RSpec.describe SpecForge::Attribute::Faker do
     end
   end
 
-  context "when the faker path has subclasses" do
-    let(:path) { "faker.games.zelda.game" }
+  context "when the faker input has subclasses" do
+    let(:input) { "faker.games.zelda.game" }
 
     it "parses the faker class and method" do
       expect(attribute.faker_class).to eq(Faker::Games::Zelda)
@@ -25,9 +29,9 @@ RSpec.describe SpecForge::Attribute::Faker do
     end
   end
 
-  context "when the faker path is not valid" do
+  context "when the faker input is not valid" do
     context "due to the class not being valid" do
-      let(:path) { "faker.noop.does_not_exist" }
+      let(:input) { "faker.noop.does_not_exist" }
 
       it "is expected to raise" do
         expect { attribute }.to raise_error(SpecForge::InvalidFakerClassError)
@@ -35,7 +39,7 @@ RSpec.describe SpecForge::Attribute::Faker do
     end
 
     context "due to the method not being valid" do
-      let(:path) { "faker.string.does_not_exist" }
+      let(:input) { "faker.string.does_not_exist" }
 
       it "is expected to raise" do
         expect { attribute }.to raise_error(SpecForge::InvalidFakerMethodError)
@@ -44,7 +48,7 @@ RSpec.describe SpecForge::Attribute::Faker do
   end
 
   context "when the Faker method takes positional arguments" do
-    let(:path) { "faker.testing.positional" }
+    let(:input) { "faker.testing.positional" }
 
     before do
       # Apparently, Faker is good at always having a default lol
@@ -81,7 +85,7 @@ RSpec.describe SpecForge::Attribute::Faker do
   end
 
   context "when the Faker method takes keyword arguments" do
-    let(:path) { "faker.testing.keyword" }
+    let(:input) { "faker.testing.keyword" }
 
     before do
       # Apparently, Faker is good at always having a default lol
@@ -119,7 +123,7 @@ RSpec.describe SpecForge::Attribute::Faker do
 
   context "when there are method chained" do
     # Faker::Music::GratefulDead.player
-    let(:path) { "faker.music.grateful_dead.player.upcase" }
+    let(:input) { "faker.music.grateful_dead.player.upcase" }
 
     it "is expected to call the chain" do
       expect(attribute.value).to match(/[AZ ]+/)

--- a/spec/lib/spec_forge/attribute/global_spec.rb
+++ b/spec/lib/spec_forge/attribute/global_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe SpecForge::Attribute::Global do
+  let(:input) { "" }
+
+  subject(:attribute) { described_class.new(input) }
+
+  context "when the namespace is 'variables'" do
+    let(:input) { "global.variables.my_global_var" }
+    let(:my_global_var) { Faker::String.random }
+
+    before do
+      SpecForge.context.global.update(variables: {my_global_var:})
+    end
+
+    it "is expected to be able to resolve the global variable" do
+      expect(attribute.value).to be_kind_of(SpecForge::Attribute::Variable)
+      expect(attribute.resolve).to eq(my_global_var)
+    end
+  end
+
+  context "when the namespace is not valid" do
+    let(:input) { "global.not_defined" }
+
+    it do
+      expect { attribute }.to raise_error(
+        SpecForge::InvalidGlobalNamespaceError,
+        "Invalid global namespace \"not_defined\". Currently supported namespaces are: \"variables\""
+      )
+    end
+  end
+end

--- a/spec/lib/spec_forge/attribute/global_spec.rb
+++ b/spec/lib/spec_forge/attribute/global_spec.rb
@@ -29,4 +29,12 @@ RSpec.describe SpecForge::Attribute::Global do
       )
     end
   end
+
+  include_examples "from_input_to_attribute" do
+    let(:input) { "global.variables.var" }
+
+    before do
+      SpecForge.context.global.update(variables: {var: 1})
+    end
+  end
 end

--- a/spec/lib/spec_forge/attribute/literal_spec.rb
+++ b/spec/lib/spec_forge/attribute/literal_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe SpecForge::Attribute::Literal do
 
   subject(:attribute) { described_class.new(input) }
 
+  include_examples "from_input_to_attribute" do
+    let(:input) { 1 }
+  end
+
   describe "#value" do
     subject(:value) { attribute.value }
 

--- a/spec/lib/spec_forge/attribute/matcher_spec.rb
+++ b/spec/lib/spec_forge/attribute/matcher_spec.rb
@@ -7,6 +7,18 @@ RSpec.describe SpecForge::Attribute::Matcher do
 
   subject(:attribute) { described_class.new(input, positional, keyword) }
 
+  include_examples "from_input_to_attribute" do
+    let(:input) { "kind_of.string" }
+  end
+
+  include_examples "from_input_to_attribute" do
+    let(:input) { "be.nil" }
+  end
+
+  include_examples "from_input_to_attribute" do
+    let(:input) { "matcher.include" }
+  end
+
   describe "KEYWORD_REGEX" do
     subject(:regex) { described_class::KEYWORD_REGEX }
 

--- a/spec/lib/spec_forge/attribute/regex_spec.rb
+++ b/spec/lib/spec_forge/attribute/regex_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe SpecForge::Attribute::Regex do
 
   subject(:attribute) { described_class.new(input) }
 
+  include_examples "from_input_to_attribute" do
+    let(:input) { "/my_regex/i" }
+  end
+
   describe "#value" do
     subject(:value) { attribute.value }
 

--- a/spec/lib/spec_forge/attribute/transform_spec.rb
+++ b/spec/lib/spec_forge/attribute/transform_spec.rb
@@ -1,20 +1,27 @@
 # frozen_string_literal: true
 
 RSpec.describe SpecForge::Attribute::Transform do
-  let(:function) { "" }
+  let(:input) { "" }
   let(:positional) { [] }
   let(:keyword) { {} }
 
-  subject(:attribute) { described_class.new(function, positional, keyword) }
+  subject(:attribute) { described_class.new(input, positional, keyword) }
 
-  context "when the function is not defined" do
+  include_examples "from_input_to_attribute" do
+    # Transforms are only detected when defined as a hash
+    let(:input) { {"transform.join": []} }
+  end
+
+  context "when the input is not defined" do
+    let(:input) { "" }
+
     it "is expected to raise" do
       expect { attribute }.to raise_error(SpecForge::InvalidTransformFunctionError)
     end
   end
 
   describe "transform.join" do
-    let(:function) { "transform.join" }
+    let(:input) { "transform.join" }
 
     context "when the joining items are literals" do
       let(:positional) { ["foo", " ", "bar"] }

--- a/spec/lib/spec_forge/attribute/variable_spec.rb
+++ b/spec/lib/spec_forge/attribute/variable_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe SpecForge::Attribute::Variable do
     variable
   end
 
+  include_examples "from_input_to_attribute" do
+    let(:input) { "variables.foobar" }
+  end
+
   context "when just the variable name is referenced" do
     let(:input) { "variable.id" }
     let(:variables) { {id: Faker::String.random} }

--- a/spec/lib/spec_forge/normalizer/spec_spec.rb
+++ b/spec/lib/spec_forge/normalizer/spec_spec.rb
@@ -426,8 +426,18 @@ RSpec.describe SpecForge::Normalizer do
         it do
           expect { normalized }.to raise_error(
             SpecForge::InvalidStructureError,
-            "Expected Integer, got NilClass for \"status\" in expect (item 0)"
+            "Expected Integer or String, got NilClass for \"status\" in expect (item 0)"
           )
+        end
+      end
+
+      context "when 'status' is a String" do
+        before do
+          constraint[:status] = "global.variables.status"
+        end
+
+        it do
+          expect(normalized_constraint[:status]).to eq("global.variables.status")
         end
       end
 

--- a/spec/lib/spec_forge/spec/expectation/constraint_spec.rb
+++ b/spec/lib/spec_forge/spec/expectation/constraint_spec.rb
@@ -12,12 +12,25 @@ RSpec.describe SpecForge::Spec::Expectation::Constraint do
   end
 
   describe "#initialize" do
-    context "when 'status' is provided" do
+    context "when 'status' is an Integer" do
       let(:status) { 404 }
 
       it "is expected to store the status as an integer" do
         expect(constraint.status).to eq(404)
         expect(constraint.status).to be_kind_of(SpecForge::Attribute::Literal)
+      end
+    end
+
+    context "when 'status' is resolvable as an attribute" do
+      let(:status) { "global.variables.status" }
+
+      before do
+        SpecForge.context.global.update(variables: {status: 404})
+      end
+
+      it "is expected to store the status as an integer" do
+        expect(constraint.status).to be_kind_of(SpecForge::Attribute::Global)
+        expect(constraint.status.resolve).to eq(404)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,10 @@ RSpec.configure do |config|
 
   config.before :each do
     # Reset the config
-    SpecForge.instance_variable_set(:@configuration, SpecForge::Configuration.new)
+    SpecForge.instance_variable_set(:@configuration, nil)
+
+    # Reset the context
+    SpecForge.instance_variable_set(:@context, nil)
 
     # Remove any factories that were registered
     FactoryBot::Internal.configuration.factories.clear

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples("from_input_to_attribute") do
+  context "when it is resolved via .from" do
+    subject(:attribute) { SpecForge::Attribute.from(input) }
+
+    it "is expected to convert to an instance of #{described_class}" do
+      is_expected.to be_kind_of(described_class)
+    end
+  end
+end


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of your changes -->

## Changelog

### Added
- Added support for referencing global variables through `global.variables` (`Attribute::Global`)
  ```yaml
  global:
    variables:
      api_version: "v2"
      environment: "test"

  index_user:
    path: "/{api_version}/users"
    query:
      api_version: "global.variables.api_version"
  ```

### Changed
<!-- Changes in existing functionality -->

### Removed
<!-- Now removed features -->
