### PR TITLE
chore - Move error classes under Error class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error messages with more context about the execution environment
 - Updated YARD comments with better API descriptions and examples
 - Restructured internal architecture for better separation of concerns
+- Moved all error classes under `SpecForge::Error`
 
 ### Removed
 

--- a/lib/spec_forge/attribute/chainable.rb
+++ b/lib/spec_forge/attribute/chainable.rb
@@ -137,7 +137,7 @@ module SpecForge
 
           # Try to invoke the next step
           current_object = invoke(step, next_value)
-        rescue InvalidInvocationError => e
+        rescue Error::InvalidInvocationError => e
           resolution_path[current_path] = "Error: #{e.message}"
 
           raise e.with_resolution_path(resolution_path)
@@ -205,7 +205,7 @@ module SpecForge
       #
       # @return [Object] The result of the invocation
       #
-      # @raise [InvalidInvocationError] If the step cannot be invoked on the object
+      # @raise [Error::InvalidInvocationError] If the step cannot be invoked on the object
       #
       # @private
       #
@@ -217,7 +217,7 @@ module SpecForge
         elsif method?(object, step)
           object.public_send(step)
         else
-          raise InvalidInvocationError.new(step, object)
+          raise Error::InvalidInvocationError.new(step, object)
         end
       end
 

--- a/lib/spec_forge/attribute/factory.rb
+++ b/lib/spec_forge/attribute/factory.rb
@@ -144,7 +144,9 @@ module SpecForge
           build_strategy += "_list"
         end
 
-        raise InvalidBuildStrategy, build_strategy unless BUILD_STRATEGIES.include?(build_strategy)
+        if !BUILD_STRATEGIES.include?(build_strategy)
+          raise Error::InvalidBuildStrategy, build_strategy
+        end
 
         [build_strategy, list_size]
       end

--- a/lib/spec_forge/attribute/faker.rb
+++ b/lib/spec_forge/attribute/faker.rb
@@ -75,8 +75,8 @@ module SpecForge
       #   1. The resolved Faker class (e.g., Faker::Name)
       #   2. The method object to call on that class (e.g., #first_name)
       #
-      # @raise [InvalidFakerClassError] If the specified Faker class doesn't exist
-      # @raise [InvalidFakerMethodError] If the specified method doesn't exist on the class
+      # @raise [Error::InvalidFakerClassError] If the specified Faker class doesn't exist
+      # @raise [Error::InvalidFakerMethodError] If the specified method doesn't exist on the class
       #
       # @private
       #
@@ -111,7 +111,7 @@ module SpecForge
 
         # If we get here, we consumed all parts as classes but found no method
         class_name = ([class_name] + namespace).map(&:camelize).join("::")
-        raise InvalidFakerMethodError.new(nil, "::#{class_name}".constantize)
+        raise Error::InvalidFakerMethodError.new(nil, "::#{class_name}".constantize)
       end
 
       #
@@ -122,14 +122,14 @@ module SpecForge
         faker_class = begin
           "::Faker::#{class_name.camelize}".constantize
         rescue NameError
-          raise InvalidFakerClassError, class_name
+          raise Error::InvalidFakerClassError, class_name
         end
 
         # Load the method
         faker_method = begin
           faker_class.method(method_name)
         rescue NameError
-          raise InvalidFakerMethodError.new(method_name, faker_class)
+          raise Error::InvalidFakerMethodError.new(method_name, faker_class)
         end
 
         [faker_class, faker_method]

--- a/lib/spec_forge/attribute/global.rb
+++ b/lib/spec_forge/attribute/global.rb
@@ -44,14 +44,17 @@ module SpecForge
       # Parses the input string to extract the namespace to validate it
       # Conversion happens when `#value` is called
       #
-      # @raise [InvalidGlobalNamespaceError] If an unsupported namespace is referenced
+      # @raise [Error::InvalidGlobalNamespaceError] If an unsupported namespace is referenced
       #
       def initialize(...)
         super
 
         # Check to make sure the namespace is valid
         namespace = input.split(".").second
-        raise InvalidGlobalNamespaceError, namespace unless VALID_NAMESPACES.include?(namespace)
+
+        if !VALID_NAMESPACES.include?(namespace)
+          raise Error::InvalidGlobalNamespaceError, namespace
+        end
       end
 
       #

--- a/lib/spec_forge/attribute/transform.rb
+++ b/lib/spec_forge/attribute/transform.rb
@@ -45,7 +45,7 @@ module SpecForge
         # Remove prefix
         @function = @input.sub("transform.", "")
 
-        raise InvalidTransformFunctionError, input unless TRANSFORM_METHODS.include?(function)
+        raise Error::InvalidTransformFunctionError, input unless TRANSFORM_METHODS.include?(function)
 
         prepare_arguments!
       end

--- a/lib/spec_forge/attribute/variable.rb
+++ b/lib/spec_forge/attribute/variable.rb
@@ -33,14 +33,16 @@ module SpecForge
       #
       # @param variables [Hash] A hash of variables to look up in
       #
-      # @raise [MissingVariableError] If the variable is not found
-      # @raise [InvalidTypeError] If variables is not a hash
+      # @raise [Error::MissingVariableError] If the variable is not found
+      # @raise [Error::InvalidTypeError] If variables is not a hash
       #
       def bind_variables(variables)
-        raise InvalidTypeError.new(variables, Hash, for: "'variables'") unless Type.hash?(variables)
+        if !Type.hash?(variables)
+          raise Error::InvalidTypeError.new(variables, Hash, for: "'variables'")
+        end
 
         # Don't nil check here.
-        raise MissingVariableError, variable_name unless variables.key?(variable_name)
+        raise Error::MissingVariableError, variable_name unless variables.key?(variable_name)
 
         @variable = variables[variable_name]
       end

--- a/lib/spec_forge/error.rb
+++ b/lib/spec_forge/error.rb
@@ -1,228 +1,228 @@
 # frozen_string_literal: true
 
 module SpecForge
-  # Pass into to_sentence
-  OR_CONNECTOR = {
-    last_word_connector: ", or ",
-    two_words_connector: " or ",
-    # This is a minor performance improvement to avoid locales being loaded
-    # This will need to be removed if locales are added
-    locale: false
-  }.freeze
-
-  private_constant :OR_CONNECTOR
-
   #
   # Base error class for all SpecForge-specific exceptions
   #
-  class Error < StandardError; end
+  class Error < StandardError
+    # Pass into to_sentence
+    OR_CONNECTOR = {
+      last_word_connector: ", or ",
+      two_words_connector: " or ",
+      # This is a minor performance improvement to avoid locales being loaded
+      # This will need to be removed if locales are added
+      locale: false
+    }.freeze
 
-  #
-  # Raised when a provided Faker class name doesn't exist
-  # Provides helpful suggestions for similar class names
-  #
-  # @example
-  #   Attribute::Faker.new("faker.invalid.method")
-  #   # => InvalidFakerClassError: Undefined Faker class "invalid". Did you mean? name, games, ...
-  #
-  class InvalidFakerClassError < Error
+    private_constant :OR_CONNECTOR
+
     #
-    # A spell checker for Faker classes
+    # Raised when a provided Faker class name doesn't exist
+    # Provides helpful suggestions for similar class names
     #
-    # @return [DidYouMean::SpellChecker]
+    # @example
+    #   Attribute::Faker.new("faker.invalid.method")
+    #   # => InvalidFakerClassError: Undefined Faker class "invalid". Did you mean? name, games, ...
     #
-    CLASS_CHECKER = DidYouMean::SpellChecker.new(
-      dictionary: Faker::Base.descendants.map { |c| c.to_s.downcase.gsub!("::", ".") }
-    )
-
-    def initialize(input)
-      corrections = CLASS_CHECKER.correct(input)
-
-      super(<<~STRING.chomp
-        Undefined Faker class "#{input}". #{DidYouMean::Formatter.message_for(corrections)}
-
-        For available classes, please check https://github.com/faker-ruby/faker#generators.
-      STRING
+    class InvalidFakerClassError < Error
+      #
+      # A spell checker for Faker classes
+      #
+      # @return [DidYouMean::SpellChecker]
+      #
+      CLASS_CHECKER = DidYouMean::SpellChecker.new(
+        dictionary: Faker::Base.descendants.map { |c| c.to_s.downcase.gsub!("::", ".") }
       )
-    end
-  end
 
-  #
-  # Raised when a provided method for a Faker class doesn't exist
-  # Provides helpful suggestions for similar method names
-  #
-  # @example
-  #   Attribute::Faker.new("faker.name.invlaid")
-  #   # => InvalidFakerMethodError: Undefined Faker method "invlaid" for "Faker::Name".
-  #                                 Did you mean? first_name, last_name, ...
-  #
-  class InvalidFakerMethodError < Error
-    def initialize(input, klass)
-      spell_checker = DidYouMean::SpellChecker.new(dictionary: klass.public_methods)
-      corrections = spell_checker.correct(input)
+      def initialize(input)
+        corrections = CLASS_CHECKER.correct(input)
 
-      super(<<~STRING.chomp
-        Undefined Faker method "#{input}" for "#{klass}". #{DidYouMean::Formatter.message_for(corrections)}
+        super(<<~STRING.chomp
+          Undefined Faker class "#{input}". #{DidYouMean::Formatter.message_for(corrections)}
 
-        For available methods for this class, please check https://github.com/faker-ruby/faker#generators.
-      STRING
-      )
-    end
-  end
-
-  #
-  # Raised when an unknown transform function is referenced
-  # Indicates when a transform name isn't supported
-  #
-  class InvalidTransformFunctionError < Error
-    def initialize(input)
-      # TODO: Update link to docs
-      super(<<~STRING.chomp
-        Undefined transform function "#{input}".
-
-        For available functions, please check https://github.com/itsthedevman/spec_forge.
-      STRING
-      )
-    end
-  end
-
-  #
-  # Raised when a step in an invocation chain is invalid
-  # Provides detailed information about where in the chain the error occurred
-  #
-  # @example
-  #   variable_attr = Attribute::Variable.new("variables.user.invalid_method")
-  #   variable_attr.resolve
-  #   # => InvalidInvocationError: Cannot invoke "invalid_method" on User
-  #
-  class InvalidInvocationError < Error
-    def initialize(step, object, resolution_path = {})
-      @step = step
-      @object = object
-      @resolution_path = resolution_path
-
-      super(<<~STRING.chomp
-        Cannot invoke "#{step}" on #{object.class}
-        #{resolution_path_message}
-      STRING
-      )
+          For available classes, please check https://github.com/faker-ruby/faker#generators.
+        STRING
+        )
+      end
     end
 
     #
-    # Creates a new InvalidInvocationError with a new resolution path
+    # Raised when a provided method for a Faker class doesn't exist
+    # Provides helpful suggestions for similar method names
     #
-    # @param path [Hash] The steps taken up until this point
+    # @example
+    #   Attribute::Faker.new("faker.name.invlaid")
+    #   # => InvalidFakerMethodError: Undefined Faker method "invlaid" for "Faker::Name".
+    #                                 Did you mean? first_name, last_name, ...
     #
-    def with_resolution_path(path)
-      self.class.new(@step, @object, path)
+    class InvalidFakerMethodError < Error
+      def initialize(input, klass)
+        spell_checker = DidYouMean::SpellChecker.new(dictionary: klass.public_methods)
+        corrections = spell_checker.correct(input)
+
+        super(<<~STRING.chomp
+          Undefined Faker method "#{input}" for "#{klass}". #{DidYouMean::Formatter.message_for(corrections)}
+
+          For available methods for this class, please check https://github.com/faker-ruby/faker#generators.
+        STRING
+        )
+      end
     end
 
-    private
+    #
+    # Raised when an unknown transform function is referenced
+    # Indicates when a transform name isn't supported
+    #
+    class InvalidTransformFunctionError < Error
+      def initialize(input)
+        # TODO: Update link to docs
+        super(<<~STRING.chomp
+          Undefined transform function "#{input}".
 
-    def resolution_path_message
-      return "" if @resolution_path.empty?
-
-      message =
-        @resolution_path.map.with_index do |(path, description), index|
-          "#{index + 1}. #{path} --> #{description}"
-        end.join("\n")
-
-      "\nResolution path:\n#{message}"
+          For available functions, please check https://github.com/itsthedevman/spec_forge.
+        STRING
+        )
+      end
     end
-  end
 
-  #
-  # An extended version of TypeError with better error messages
-  # Makes it easier to understand type mismatches in the codebase
-  #
-  # @example
-  #   raise InvalidTypeError.new(123, String, for: "name parameter")
-  #   # => Expected String, got Integer for name parameter
-  #
-  class InvalidTypeError < Error
-    def initialize(object, expected_type, **opts)
-      if expected_type.instance_of?(Array)
-        expected_type = expected_type.to_sentence(**OR_CONNECTOR)
+    #
+    # Raised when a step in an invocation chain is invalid
+    # Provides detailed information about where in the chain the error occurred
+    #
+    # @example
+    #   variable_attr = Attribute::Variable.new("variables.user.invalid_method")
+    #   variable_attr.resolve
+    #   # => InvalidInvocationError: Cannot invoke "invalid_method" on User
+    #
+    class InvalidInvocationError < Error
+      def initialize(step, object, resolution_path = {})
+        @step = step
+        @object = object
+        @resolution_path = resolution_path
+
+        super(<<~STRING.chomp
+          Cannot invoke "#{step}" on #{object.class}
+          #{resolution_path_message}
+        STRING
+        )
       end
 
-      message = "Expected #{expected_type}, got #{object.class}"
-      message += " for #{opts[:for]}" if opts[:for].present?
-
-      super(message)
-    end
-  end
-
-  #
-  # Raised when a variable reference cannot be resolved
-  # Indicates when a spec or expectation references an undefined variable
-  #
-  class MissingVariableError < Error
-    def initialize(variable_name)
-      super("Undefined variable \"#{variable_name}\" referenced in expectation")
-    end
-  end
-
-  #
-  # Raised when a YAML structure doesn't match expectations
-  # Acts as a container for multiple validation errors
-  #
-  class InvalidStructureError < Error
-    def initialize(errors)
-      message = errors.to_a.join_map("\n") do |error|
-        next error if error.is_a?(SpecForge::Error)
-
-        # Normal errors, let's get verbose
-        backtrace = SpecForge.backtrace_cleaner.clean(error.backtrace)
-        "#{error.inspect}\n  # ./#{backtrace.join("\n  # ./")}\n"
+      #
+      # Creates a new InvalidInvocationError with a new resolution path
+      #
+      # @param path [Hash] The steps taken up until this point
+      #
+      def with_resolution_path(path)
+        self.class.new(@step, @object, path)
       end
 
-      super(message)
+      private
+
+      def resolution_path_message
+        return "" if @resolution_path.empty?
+
+        message =
+          @resolution_path.map.with_index do |(path, description), index|
+            "#{index + 1}. #{path} --> #{description}"
+          end.join("\n")
+
+        "\nResolution path:\n#{message}"
+      end
     end
-  end
 
-  #
-  # Raised when an unknown factory build strategy is provided
-  # Indicates when a strategy string doesn't match supported options
-  #
-  class InvalidBuildStrategy < Error
-    def initialize(build_strategy)
-      valid_strategies = Attribute::Factory::BUILD_STRATEGIES.to_sentence(**OR_CONNECTOR)
-
-      super(<<~STRING.chomp
-        Unknown build strategy "#{build_strategy}" referenced in spec.
-
-        Valid strategies include: #{valid_strategies}
-      STRING
-      )
-    end
-  end
-
-  #
-  # Raised when a spec file cannot be loaded
-  # Provides detailed information about the cause of the loading error
-  #
-  class SpecLoadError < Error
-    def initialize(error, file_path)
-      message = "Error loading spec file: #{file_path}\n"
-      causes = error.message.split("\n").map(&:strip).reject(&:empty?)
-
-      message +=
-        if causes.size > 1
-          "Causes:\n  - #{causes.join_map("\n  - ")}"
-        else
-          "Cause: #{error}"
+    #
+    # An extended version of TypeError with better error messages
+    # Makes it easier to understand type mismatches in the codebase
+    #
+    # @example
+    #   raise Error::InvalidTypeError.new(123, String, for: "name parameter")
+    #   # => Expected String, got Integer for name parameter
+    #
+    class InvalidTypeError < Error
+      def initialize(object, expected_type, **opts)
+        if expected_type.instance_of?(Array)
+          expected_type = expected_type.to_sentence(**OR_CONNECTOR)
         end
 
-      super(message)
-    end
-  end
+        message = "Expected #{expected_type}, got #{object.class}"
+        message += " for #{opts[:for]}" if opts[:for].present?
 
-  #
-  # Raised when the provided namespace is not defined on the global context
-  #
-  class InvalidGlobalNamespaceError < Error
-    def initialize(provided_namespace)
-      super("Invalid global namespace #{provided_namespace.in_quotes}. Currently supported namespaces are: \"variables\"")
+        super(message)
+      end
+    end
+
+    #
+    # Raised when a variable reference cannot be resolved
+    # Indicates when a spec or expectation references an undefined variable
+    #
+    class MissingVariableError < Error
+      def initialize(variable_name)
+        super("Undefined variable \"#{variable_name}\" referenced in expectation")
+      end
+    end
+
+    #
+    # Raised when a YAML structure doesn't match expectations
+    # Acts as a container for multiple validation errors
+    #
+    class InvalidStructureError < Error
+      def initialize(errors)
+        message = errors.to_a.join_map("\n") do |error|
+          next error if error.is_a?(SpecForge::Error)
+
+          # Normal errors, let's get verbose
+          backtrace = SpecForge.backtrace_cleaner.clean(error.backtrace)
+          "#{error.inspect}\n  # ./#{backtrace.join("\n  # ./")}\n"
+        end
+
+        super(message)
+      end
+    end
+
+    #
+    # Raised when an unknown factory build strategy is provided
+    # Indicates when a strategy string doesn't match supported options
+    #
+    class InvalidBuildStrategy < Error
+      def initialize(build_strategy)
+        valid_strategies = Attribute::Factory::BUILD_STRATEGIES.to_sentence(**OR_CONNECTOR)
+
+        super(<<~STRING.chomp
+          Unknown build strategy "#{build_strategy}" referenced in spec.
+
+          Valid strategies include: #{valid_strategies}
+        STRING
+        )
+      end
+    end
+
+    #
+    # Raised when a spec file cannot be loaded
+    # Provides detailed information about the cause of the loading error
+    #
+    class SpecLoadError < Error
+      def initialize(error, file_path)
+        message = "Error loading spec file: #{file_path}\n"
+        causes = error.message.split("\n").map(&:strip).reject(&:empty?)
+
+        message +=
+          if causes.size > 1
+            "Causes:\n  - #{causes.join_map("\n  - ")}"
+          else
+            "Cause: #{error}"
+          end
+
+        super(message)
+      end
+    end
+
+    #
+    # Raised when the provided namespace is not defined on the global context
+    #
+    class InvalidGlobalNamespaceError < Error
+      def initialize(provided_namespace)
+        super("Invalid global namespace #{provided_namespace.in_quotes}. Currently supported namespaces are: \"variables\"")
+      end
     end
   end
 end

--- a/lib/spec_forge/loader.rb
+++ b/lib/spec_forge/loader.rb
@@ -25,14 +25,14 @@ module SpecForge
             begin
               Normalizer.normalize_global_context!(global)
             rescue => e
-              raise SpecLoadError.new(e, metadata[:relative_path])
+              raise Error::SpecLoadError.new(e, metadata[:relative_path])
             end
 
           specs =
             specs.map do |spec|
               Normalizer.normalize_spec!(spec, label: "spec \"#{spec[:name]}\"")
             rescue => e
-              raise SpecLoadError.new(e, metadata[:relative_path])
+              raise Error::SpecLoadError.new(e, metadata[:relative_path])
             end
 
           [global, metadata, specs]

--- a/lib/spec_forge/normalizer.rb
+++ b/lib/spec_forge/normalizer.rb
@@ -106,7 +106,7 @@ module SpecForge
       #
       # @return [Object] The normalized output if successful
       #
-      # @raise [InvalidStructureError] If any errors were encountered
+      # @raise [Error::InvalidStructureError] If any errors were encountered
       #
       # @private
       #
@@ -120,7 +120,7 @@ module SpecForge
           errors << e
         end
 
-        raise InvalidStructureError.new(errors) if errors.size > 0
+        raise Error::InvalidStructureError.new(errors) if errors.size > 0
 
         output
       end
@@ -229,7 +229,7 @@ module SpecForge
             for_context += " (line #{line_number})"
           end
 
-          raise InvalidTypeError.new(value, type_class, for: for_context)
+          raise Error::InvalidTypeError.new(value, type_class, for: for_context)
         end
 
         # Call the validator if it has one

--- a/lib/spec_forge/normalizer/configuration.rb
+++ b/lib/spec_forge/normalizer/configuration.rb
@@ -61,7 +61,7 @@ module SpecForge
       #
       # @return [Hash] A normalized hash with defaults applied
       #
-      # @raise [InvalidStructureError] If validation fails
+      # @raise [Error::InvalidStructureError] If validation fails
       #
       def normalize_configuration!(input)
         raise_errors! do
@@ -80,7 +80,7 @@ module SpecForge
       #
       def normalize_configuration(configuration)
         if !Type.hash?(configuration)
-          raise InvalidTypeError.new(configuration, Hash, for: "configuration")
+          raise Error::InvalidTypeError.new(configuration, Hash, for: "configuration")
         end
 
         Normalizer::Configuration.new("configuration", configuration).normalize

--- a/lib/spec_forge/normalizer/constraint.rb
+++ b/lib/spec_forge/normalizer/constraint.rb
@@ -51,7 +51,7 @@ module SpecForge
       # @private
       #
       def normalize_constraint(constraint)
-        raise InvalidTypeError.new(constraint, Hash, for: "expect") unless Type.hash?(constraint)
+        raise Error::InvalidTypeError.new(constraint, Hash, for: "expect") unless Type.hash?(constraint)
 
         Normalizer::Constraint.new("expect", constraint).normalize
       end

--- a/lib/spec_forge/normalizer/expectation.rb
+++ b/lib/spec_forge/normalizer/expectation.rb
@@ -56,7 +56,7 @@ module SpecForge
       #
       # @return [Array<Hash>] Normalized array of expectation hashes
       #
-      # @raise [InvalidStructureError] If validation fails
+      # @raise [Error::InvalidStructureError] If validation fails
       #
       def normalize_expectations!(input)
         raise_errors! do
@@ -75,7 +75,7 @@ module SpecForge
       #
       def normalize_expectations(expectations)
         if !Type.array?(expectations)
-          raise InvalidTypeError.new(expectations, Array, for: "\"expectations\" on spec")
+          raise Error::InvalidTypeError.new(expectations, Array, for: "\"expectations\" on spec")
         end
 
         final_errors = Set.new

--- a/lib/spec_forge/normalizer/factory.rb
+++ b/lib/spec_forge/normalizer/factory.rb
@@ -51,7 +51,7 @@ module SpecForge
       #
       # @return [Hash] A normalized hash with defaults applied
       #
-      # @raise [InvalidStructureError] If validation fails
+      # @raise [Error::InvalidStructureError] If validation fails
       #
       def normalize_factory!(input)
         raise_errors! do
@@ -69,7 +69,7 @@ module SpecForge
       # @private
       #
       def normalize_factory(factory)
-        raise InvalidTypeError.new(factory, Hash, for: "factory") unless Type.hash?(factory)
+        raise Error::InvalidTypeError.new(factory, Hash, for: "factory") unless Type.hash?(factory)
 
         Normalizer::Factory.new("factory", factory).normalize
       end

--- a/lib/spec_forge/normalizer/factory_reference.rb
+++ b/lib/spec_forge/normalizer/factory_reference.rb
@@ -55,7 +55,7 @@ module SpecForge
       #
       # @return [Hash] A normalized hash with defaults applied
       #
-      # @raise [InvalidStructureError] If validation fails
+      # @raise [Error::InvalidStructureError] If validation fails
       #
       def normalize_factory_reference!(input, **)
         raise_errors! do
@@ -75,7 +75,7 @@ module SpecForge
       #
       def normalize_factory_reference(factory, label: "factory reference")
         if !Type.hash?(factory)
-          raise InvalidTypeError.new(factory, Hash, for: "factory reference")
+          raise Error::InvalidTypeError.new(factory, Hash, for: "factory reference")
         end
 
         Normalizer::FactoryReference.new(label, factory).normalize

--- a/lib/spec_forge/normalizer/global_context.rb
+++ b/lib/spec_forge/normalizer/global_context.rb
@@ -42,7 +42,7 @@ module SpecForge
       #
       # @return [Hash] A normalized hash with defaults applied
       #
-      # @raise [InvalidStructureError] If validation fails
+      # @raise [Error::InvalidStructureError] If validation fails
       #
       def normalize_global_context!(input)
         raise_errors! do
@@ -61,7 +61,7 @@ module SpecForge
       #
       def normalize_global_context(global)
         if !Type.hash?(global)
-          raise InvalidTypeError.new(global, Hash, for: "global context")
+          raise Error::InvalidTypeError.new(global, Hash, for: "global context")
         end
 
         Normalizer::GlobalContext.new("global context", global).normalize

--- a/lib/spec_forge/normalizer/spec.rb
+++ b/lib/spec_forge/normalizer/spec.rb
@@ -59,7 +59,7 @@ module SpecForge
       #
       # @return [Hash] A normalized hash with defaults applied
       #
-      # @raise [InvalidStructureError] If validation fails
+      # @raise [Error::InvalidStructureError] If validation fails
       #
       def normalize_spec!(input, label: "spec")
         raise_errors! do
@@ -88,7 +88,7 @@ module SpecForge
       # @private
       #
       def normalize_spec(spec, label: "spec")
-        raise InvalidTypeError.new(spec, Hash, for: label) unless Type.hash?(spec)
+        raise Error::InvalidTypeError.new(spec, Hash, for: label) unless Type.hash?(spec)
 
         Normalizer::Spec.new(label, spec).normalize
       end

--- a/spec/lib/spec_forge/attribute/chainable_spec.rb
+++ b/spec/lib/spec_forge/attribute/chainable_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe SpecForge::Attribute::Chainable do
     let(:input) { "key.header.key_1.foo" }
 
     it "is expected to provide a helpful error message" do
-      expect { attribute.value }.to raise_error(SpecForge::InvalidInvocationError) do |e|
+      expect { attribute.value }.to raise_error(SpecForge::Error::InvalidInvocationError) do |e|
         expect(e.message).to eq <<~STRING
           Cannot invoke "foo" on Integer
 
@@ -67,7 +67,7 @@ RSpec.describe SpecForge::Attribute::Chainable do
     let(:input) { "key.header.items.invalid" }
 
     it "is expected to provide a helpful error" do
-      expect { attribute.value }.to raise_error(SpecForge::InvalidInvocationError) do |e|
+      expect { attribute.value }.to raise_error(SpecForge::Error::InvalidInvocationError) do |e|
         expect(e.message).to eq <<~STRING
           Cannot invoke "invalid" on Array
 
@@ -84,7 +84,7 @@ RSpec.describe SpecForge::Attribute::Chainable do
     let(:input) { "key.header.missing.property" }
 
     it "is expected to provide a helpful error about nil" do
-      expect { attribute.value }.to raise_error(SpecForge::InvalidInvocationError) do |e|
+      expect { attribute.value }.to raise_error(SpecForge::Error::InvalidInvocationError) do |e|
         expect(e.message).to eq <<~STRING
           Cannot invoke "missing" on Hash
 
@@ -108,7 +108,7 @@ RSpec.describe SpecForge::Attribute::Chainable do
     let(:input) { "key.header.methods.hello.upcase" }
 
     it "is expected to provide a helpful error" do
-      expect { attribute.value }.to raise_error(SpecForge::InvalidInvocationError) do |e|
+      expect { attribute.value }.to raise_error(SpecForge::Error::InvalidInvocationError) do |e|
         expect(e.message).to match <<~STRING
           Cannot invoke "upcase" on Proc
 

--- a/spec/lib/spec_forge/attribute/faker_spec.rb
+++ b/spec/lib/spec_forge/attribute/faker_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe SpecForge::Attribute::Faker do
       let(:input) { "faker.noop.does_not_exist" }
 
       it "is expected to raise" do
-        expect { attribute }.to raise_error(SpecForge::InvalidFakerClassError)
+        expect { attribute }.to raise_error(SpecForge::Error::InvalidFakerClassError)
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe SpecForge::Attribute::Faker do
       let(:input) { "faker.string.does_not_exist" }
 
       it "is expected to raise" do
-        expect { attribute }.to raise_error(SpecForge::InvalidFakerMethodError)
+        expect { attribute }.to raise_error(SpecForge::Error::InvalidFakerMethodError)
       end
     end
   end

--- a/spec/lib/spec_forge/attribute/global_spec.rb
+++ b/spec/lib/spec_forge/attribute/global_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe SpecForge::Attribute::Global do
 
     it do
       expect { attribute }.to raise_error(
-        SpecForge::InvalidGlobalNamespaceError,
+        SpecForge::Error::InvalidGlobalNamespaceError,
         "Invalid global namespace \"not_defined\". Currently supported namespaces are: \"variables\""
       )
     end

--- a/spec/lib/spec_forge/attribute/transform_spec.rb
+++ b/spec/lib/spec_forge/attribute/transform_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SpecForge::Attribute::Transform do
     let(:input) { "" }
 
     it "is expected to raise" do
-      expect { attribute }.to raise_error(SpecForge::InvalidTransformFunctionError)
+      expect { attribute }.to raise_error(SpecForge::Error::InvalidTransformFunctionError)
     end
   end
 

--- a/spec/lib/spec_forge/attribute/variable_spec.rb
+++ b/spec/lib/spec_forge/attribute/variable_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe SpecForge::Attribute::Variable do
         expect(variable.variable_name).to eq(:hash)
         expect(variable.invocation_chain).to eq(["1"])
 
-        expect { variable.value }.to raise_error(SpecForge::InvalidInvocationError)
+        expect { variable.value }.to raise_error(SpecForge::Error::InvalidInvocationError)
       end
     end
   end
@@ -73,7 +73,7 @@ RSpec.describe SpecForge::Attribute::Variable do
         expect(variable.variable_name).to eq(:array)
         expect(variable.invocation_chain).to eq(["key_1"])
 
-        expect { variable.value }.to raise_error(SpecForge::InvalidInvocationError)
+        expect { variable.value }.to raise_error(SpecForge::Error::InvalidInvocationError)
       end
     end
 
@@ -127,7 +127,7 @@ RSpec.describe SpecForge::Attribute::Variable do
         expect(variable.variable_name).to eq(:object)
         expect(variable.invocation_chain).to eq(["key_1"])
 
-        expect { variable.value }.to raise_error(SpecForge::InvalidInvocationError)
+        expect { variable.value }.to raise_error(SpecForge::Error::InvalidInvocationError)
       end
     end
 
@@ -149,7 +149,7 @@ RSpec.describe SpecForge::Attribute::Variable do
         expect(variable.variable_name).to eq(:object)
         expect(variable.invocation_chain).to eq(["0"])
 
-        expect { variable.value }.to raise_error(SpecForge::InvalidInvocationError)
+        expect { variable.value }.to raise_error(SpecForge::Error::InvalidInvocationError)
       end
     end
   end
@@ -159,7 +159,7 @@ RSpec.describe SpecForge::Attribute::Variable do
     let(:variables) { {object: Data.define.new} }
 
     it do
-      expect { variable.value }.to raise_error(SpecForge::InvalidInvocationError)
+      expect { variable.value }.to raise_error(SpecForge::Error::InvalidInvocationError)
     end
   end
 
@@ -167,7 +167,7 @@ RSpec.describe SpecForge::Attribute::Variable do
     let(:input) { "variables." }
 
     it do
-      expect { variable.value }.to raise_error(SpecForge::MissingVariableError)
+      expect { variable.value }.to raise_error(SpecForge::Error::MissingVariableError)
     end
   end
 
@@ -196,7 +196,7 @@ RSpec.describe SpecForge::Attribute::Variable do
 
     it do
       expect { variable }.to raise_error(
-        SpecForge::InvalidTypeError,
+        SpecForge::Error::InvalidTypeError,
         "Expected Hash, got NilClass for 'variables'"
       )
     end

--- a/spec/lib/spec_forge/configuration_spec.rb
+++ b/spec/lib/spec_forge/configuration_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe SpecForge::Configuration do
 
       it do
         expect { validated }.to raise_error(
-          SpecForge::InvalidStructureError,
+          SpecForge::Error::InvalidStructureError,
           "Expected String, got NilClass for \"base_url\" in configuration"
         )
       end
@@ -135,7 +135,7 @@ RSpec.describe SpecForge::Configuration do
 
       it do
         expect { validated }.to raise_error(
-          SpecForge::InvalidStructureError,
+          SpecForge::Error::InvalidStructureError,
           "Expected String, got Integer for \"base_url\" in configuration"
         )
       end
@@ -155,7 +155,7 @@ RSpec.describe SpecForge::Configuration do
 
       it do
         expect { validated }.to raise_error(
-          SpecForge::InvalidStructureError,
+          SpecForge::Error::InvalidStructureError,
           "Expected Hash, got Integer for \"headers\" in configuration"
         )
       end
@@ -175,7 +175,7 @@ RSpec.describe SpecForge::Configuration do
 
       it do
         expect { validated }.to raise_error(
-          SpecForge::InvalidStructureError,
+          SpecForge::Error::InvalidStructureError,
           "Expected Hash, got Integer for \"query\" (aliases \"params\") in configuration"
         )
       end
@@ -186,7 +186,7 @@ RSpec.describe SpecForge::Configuration do
 
       it do
         expect { validated }.to raise_error(
-          SpecForge::InvalidStructureError,
+          SpecForge::Error::InvalidStructureError,
           "Expected Proc, got NilClass for \"on_debug\" in configuration"
         )
       end
@@ -197,7 +197,7 @@ RSpec.describe SpecForge::Configuration do
 
       it do
         expect { validated }.to raise_error(
-          SpecForge::InvalidStructureError,
+          SpecForge::Error::InvalidStructureError,
           "Expected Proc, got Integer for \"on_debug\" in configuration"
         )
       end

--- a/spec/lib/spec_forge/error_spec.rb
+++ b/spec/lib/spec_forge/error_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe SpecForge::Error do
-  describe SpecForge::InvalidFakerClassError do
+  describe SpecForge::Error::InvalidFakerClassError do
     let(:input) { "faker.nuumbre" }
 
     subject(:error) { described_class.new(input) }
@@ -11,7 +11,7 @@ RSpec.describe SpecForge::Error do
     end
   end
 
-  describe SpecForge::InvalidFakerMethodError do
+  describe SpecForge::Error::InvalidFakerMethodError do
     let(:input) { "psoitive" }
 
     subject(:error) { described_class.new(input, Faker::Number) }
@@ -21,7 +21,7 @@ RSpec.describe SpecForge::Error do
     end
   end
 
-  describe SpecForge::InvalidTypeError do
+  describe SpecForge::Error::InvalidTypeError do
     let(:input) { nil }
     let(:expected_type) {}
     let(:for_thing) {}

--- a/spec/lib/spec_forge/loader_spec.rb
+++ b/spec/lib/spec_forge/loader_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe SpecForge::Loader do
       end
 
       it do
-        expect { specs }.to raise_error(SpecForge::SpecLoadError) do |e|
+        expect { specs }.to raise_error(SpecForge::Error::SpecLoadError) do |e|
           expect(e.message).to include("Error loading spec file: spec_1.yml")
           expect(e.message).to include("Cause: Expected Hash, got Integer")
         end
@@ -79,7 +79,7 @@ RSpec.describe SpecForge::Loader do
       end
 
       it do
-        expect { specs }.to raise_error(SpecForge::SpecLoadError) do |e|
+        expect { specs }.to raise_error(SpecForge::Error::SpecLoadError) do |e|
           expect(e.message).to include("Error loading spec file: spec_2.yml")
           expect(e.message).to include("Causes:")
           expect(e.message).to include(

--- a/spec/lib/spec_forge/normalizer/factory_reference_spec.rb
+++ b/spec/lib/spec_forge/normalizer/factory_reference_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe SpecForge::Normalizer do
 
       it do
         expect { normalized }.to raise_error(
-          SpecForge::InvalidStructureError,
+          SpecForge::Error::InvalidStructureError,
           "Expected String, got Integer for \"build_strategy\" (aliases \"strategy\") in factory reference"
         )
       end
@@ -60,7 +60,7 @@ RSpec.describe SpecForge::Normalizer do
 
       it do
         expect { normalized }.to raise_error(
-          SpecForge::InvalidStructureError,
+          SpecForge::Error::InvalidStructureError,
           "Expected Hash, got Integer for \"attributes\" in factory reference"
         )
       end
@@ -83,7 +83,7 @@ RSpec.describe SpecForge::Normalizer do
 
       it do
         expect { normalized }.to raise_error(
-          SpecForge::InvalidStructureError,
+          SpecForge::Error::InvalidStructureError,
           "Expected Integer, got Float for \"size\" (aliases \"count\") in factory reference"
         )
       end

--- a/spec/lib/spec_forge/normalizer/factory_spec.rb
+++ b/spec/lib/spec_forge/normalizer/factory_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe SpecForge::Normalizer do
 
       it do
         expect { normalized }.to raise_error(
-          SpecForge::InvalidStructureError,
+          SpecForge::Error::InvalidStructureError,
           "Expected String, got Integer for \"model_class\" (aliases \"class\") in factory"
         )
       end
@@ -82,7 +82,7 @@ RSpec.describe SpecForge::Normalizer do
 
       it do
         expect { normalized }.to raise_error(
-          SpecForge::InvalidStructureError,
+          SpecForge::Error::InvalidStructureError,
           "Expected Hash, got Integer for \"variables\" in factory"
         )
       end
@@ -105,7 +105,7 @@ RSpec.describe SpecForge::Normalizer do
 
       it do
         expect { normalized }.to raise_error(
-          SpecForge::InvalidStructureError,
+          SpecForge::Error::InvalidStructureError,
           "Expected Hash, got Integer for \"attributes\" in factory"
         )
       end

--- a/spec/lib/spec_forge/normalizer/global_context_spec.rb
+++ b/spec/lib/spec_forge/normalizer/global_context_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe SpecForge::Normalizer do
 
       it do
         expect { normalized }.to raise_error(
-          SpecForge::InvalidStructureError,
+          SpecForge::Error::InvalidStructureError,
           "Expected Hash, got Integer for \"variables\" in global context"
         )
       end

--- a/spec/lib/spec_forge/normalizer/spec_spec.rb
+++ b/spec/lib/spec_forge/normalizer/spec_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe SpecForge::Normalizer do
 
         it do
           expect { normalized }.to raise_error(
-            SpecForge::InvalidStructureError,
+            SpecForge::Error::InvalidStructureError,
             "Expected String, got Integer for \"base_url\" in spec (line 1)"
           )
         end
@@ -147,7 +147,7 @@ RSpec.describe SpecForge::Normalizer do
 
         it do
           expect { normalized }.to raise_error(
-            SpecForge::InvalidStructureError,
+            SpecForge::Error::InvalidStructureError,
             "Expected String, got Integer for \"url\" (aliases \"path\") in spec (line 1)"
           )
         end
@@ -170,7 +170,7 @@ RSpec.describe SpecForge::Normalizer do
 
         it do
           expect { normalized }.to raise_error(
-            SpecForge::InvalidStructureError,
+            SpecForge::Error::InvalidStructureError,
             "Expected String, got Integer for \"http_verb\" (aliases \"method\", \"http_method\") in spec (line 1)"
           )
         end
@@ -193,7 +193,7 @@ RSpec.describe SpecForge::Normalizer do
 
         it do
           expect { normalized }.to raise_error(
-            SpecForge::InvalidStructureError,
+            SpecForge::Error::InvalidStructureError,
             "Expected Hash, got Integer for \"headers\" in spec (line 1)"
           )
         end
@@ -220,7 +220,7 @@ RSpec.describe SpecForge::Normalizer do
 
         it do
           expect { normalized }.to raise_error(
-            SpecForge::InvalidStructureError,
+            SpecForge::Error::InvalidStructureError,
             "Expected Hash, got Integer for \"query\" (aliases \"params\") in spec (line 1)"
           )
         end
@@ -243,7 +243,7 @@ RSpec.describe SpecForge::Normalizer do
 
         it do
           expect { normalized }.to raise_error(
-            SpecForge::InvalidStructureError,
+            SpecForge::Error::InvalidStructureError,
             "Expected Hash, got Integer for \"body\" (aliases \"data\") in spec (line 1)"
           )
         end
@@ -266,7 +266,7 @@ RSpec.describe SpecForge::Normalizer do
 
         it do
           expect { normalized }.to raise_error(
-            SpecForge::InvalidStructureError,
+            SpecForge::Error::InvalidStructureError,
             "Expected Hash, got Integer for \"variables\" in spec (line 1)"
           )
         end
@@ -279,7 +279,7 @@ RSpec.describe SpecForge::Normalizer do
 
         it do
           expect { normalized }.to raise_error(
-            SpecForge::InvalidStructureError,
+            SpecForge::Error::InvalidStructureError,
             "Expected Array, got NilClass for \"expectations\" in spec (line 1)"
           )
         end
@@ -292,7 +292,7 @@ RSpec.describe SpecForge::Normalizer do
 
         it do
           expect { normalized }.to raise_error(
-            SpecForge::InvalidStructureError,
+            SpecForge::Error::InvalidStructureError,
             "Expected Array, got Integer for \"expectations\" in spec (line 1)"
           )
         end
@@ -336,7 +336,7 @@ RSpec.describe SpecForge::Normalizer do
 
         it do
           expect { normalized }.to raise_error(
-            SpecForge::InvalidStructureError,
+            SpecForge::Error::InvalidStructureError,
             "Expected String, got Integer for \"http_verb\" (aliases \"method\", \"http_method\") in expectation (item 0) (line 5)"
           )
         end
@@ -349,7 +349,7 @@ RSpec.describe SpecForge::Normalizer do
 
         it do
           expect { normalized }.to raise_error(
-            SpecForge::InvalidStructureError,
+            SpecForge::Error::InvalidStructureError,
             "Invalid HTTP verb: TEG. Valid values are: DELETE, GET, PATCH, POST, PUT"
           )
         end
@@ -406,7 +406,7 @@ RSpec.describe SpecForge::Normalizer do
 
         it do
           expect { normalized }.to raise_error(
-            SpecForge::InvalidStructureError,
+            SpecForge::Error::InvalidStructureError,
             "Expected Hash, got NilClass for \"expect\" in expectation (item 0) (line 5)"
           )
         end
@@ -425,7 +425,7 @@ RSpec.describe SpecForge::Normalizer do
 
         it do
           expect { normalized }.to raise_error(
-            SpecForge::InvalidStructureError,
+            SpecForge::Error::InvalidStructureError,
             "Expected Integer or String, got NilClass for \"status\" in expect (item 0)"
           )
         end

--- a/spec/lib/spec_forge/normalizer_spec.rb
+++ b/spec/lib/spec_forge/normalizer_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe SpecForge::Normalizer do
 
         error = errors.first
 
-        expect(error).to be_kind_of(SpecForge::InvalidTypeError)
+        expect(error).to be_kind_of(SpecForge::Error::InvalidTypeError)
         expect(error.message).to eq(
           "Expected String, got Integer for \"key_3\" in normalizer"
         )


### PR DESCRIPTION
## Description
Moved all error classes underneath the `Error` class for better organization

## Changelog

### Changed
- Moved all error classes under `SpecForge::Error`
