### PR TITLE
feat - Add support for referencing stored test data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added line number tracking for specs and expectations
 - Added new `Runner::Callbacks` class to handle various events while specs are running
 - Added new `Runner::Metadata` class to handle setting example metadata for error reporting
-- Added support for defining stored expectations via the `store_as` key.
+- Added support for defining and retrieving stored test data via the `store_as` directive and `store` attribute.
   ```yaml
   create_user:
     path: "/users"
@@ -54,6 +54,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         email: "john@example.com"
       store_as: "created_user"
       expect:
+        status: 200
+
+  show_user:
+    path: "/users/:id"
+    query:
+      id: store.created_user.response.id
+    - expect:
         status: 200
   ```
 

--- a/lib/spec_forge/attribute.rb
+++ b/lib/spec_forge/attribute.rb
@@ -69,7 +69,7 @@ module SpecForge
     end
 
     #
-    # Creates an Attribute instance from a string, handling any macros
+    # Creates an Attribute instance from a string
     #
     # @param string [String] The input string
     #
@@ -78,26 +78,31 @@ module SpecForge
     # @private
     #
     def self.from_string(string)
-      case string
-      when Global::KEYWORD_REGEX
-        Global.new(string)
-      when Faker::KEYWORD_REGEX
-        Faker.new(string)
-      when Variable::KEYWORD_REGEX
-        Variable.new(string)
-      when Matcher::KEYWORD_REGEX
-        Matcher.new(string)
-      when Factory::KEYWORD_REGEX
-        Factory.new(string)
-      when Regex::KEYWORD_REGEX
-        Regex.new(string)
-      else
-        Literal.new(string)
-      end
+      klass =
+        case string
+        when Factory::KEYWORD_REGEX
+          Factory
+        when Faker::KEYWORD_REGEX
+          Faker
+        when Global::KEYWORD_REGEX
+          Global
+        when Matcher::KEYWORD_REGEX
+          Matcher
+        when Regex::KEYWORD_REGEX
+          Regex
+        when Store::KEYWORD_REGEX
+          Store
+        when Variable::KEYWORD_REGEX
+          Variable
+        else
+          Literal
+        end
+
+      klass.new(string)
     end
 
     #
-    # Creates an Attribute instance from a hash, handling any macros
+    # Creates an Attribute instance from a hash
     #
     # @param hash [Hash] The input hash
     #
@@ -254,5 +259,6 @@ require_relative "attribute/matcher"
 require_relative "attribute/regex"
 require_relative "attribute/resolvable_array"
 require_relative "attribute/resolvable_hash"
+require_relative "attribute/store"
 require_relative "attribute/transform"
 require_relative "attribute/variable"

--- a/lib/spec_forge/attribute/store.rb
+++ b/lib/spec_forge/attribute/store.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module SpecForge
+  class Attribute
+    #
+    # Represents an attribute that references values from stored test results
+    #
+    # This class allows accessing data from previous test executions that were
+    # saved using the `store_as` directive. It provides access to response data
+    # including status, headers, and body from previously run expectations.
+    #
+    # @example Basic usage in YAML
+    #   create_user:
+    #     path: /users
+    #     method: post
+    #     expectations:
+    #     - store_as: new_user
+    #       body:
+    #         name: faker.name.name
+    #       expect:
+    #         status: 201
+    #
+    #   get_user:
+    #     path: /users/{id}
+    #     expectations:
+    #     - query:
+    #         id: store.new_user.body.id
+    #       expect:
+    #         status: 200
+    #
+    # @example Accessing specific response components
+    #   check_status:
+    #     path: /health
+    #     expectations:
+    #     - variables:
+    #         expected_status: store.new_user.status
+    #         auth_token: store.new_user.headers.authorization
+    #         user_name: store.new_user.body.user.name
+    #       expect:
+    #         status: 200
+    #
+    class Store < Attribute
+      include Chainable
+
+      #
+      # Regular expression pattern that matches attribute keywords with this prefix
+      # Used for identifying this attribute type during parsing
+      #
+      # @return [Regexp]
+      #
+      KEYWORD_REGEX = /^store\./i
+
+      alias_method :stored_id, :header
+
+      #
+      # Returns the base object for the variable chain
+      #
+      # @return [Context::Store::Entry, nil] The stored entry or nil if not found
+      #
+      def base_object
+        @base_object ||= SpecForge.context.store[stored_id.to_s]
+      end
+    end
+  end
+end

--- a/spec/lib/spec_forge/attribute/store_spec.rb
+++ b/spec/lib/spec_forge/attribute/store_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe SpecForge::Attribute::Store do
+  let(:input) {}
+
+  subject(:attribute) { described_class.new(input) }
+
+  include_examples "from_input_to_attribute" do
+    let(:input) { "store.foobar" }
+  end
+
+  context "when the entry exists" do
+    let(:id) { SecureRandom.uuid }
+    let(:input) { "store.#{id}.variables.test" }
+
+    before do
+      SpecForge.context.store.set(
+        id,
+        scope: :spec,
+        request: {},
+        variables: {
+          test: 1
+        },
+        response: {}
+      )
+    end
+
+    it "is expected to return the value" do
+      expect(SpecForge.context.store.size).to eq(1)
+      expect(attribute.resolve).to eq(1)
+    end
+  end
+
+  context "when the entry that does not exist is referenced" do
+    let!(:input) { "store.does_not_exist.id" }
+
+    it do
+      expect { attribute.resolve }.to raise_error(SpecForge::Error::InvalidInvocationError)
+    end
+  end
+end


### PR DESCRIPTION
## Description
This update is part 2 of the storing test data. This adds `Attribute::Store` that can referenced stored test data via the `store` keyword. 

Both file and spec scoped entries can be accessed via this keyword. When accessing stored data scoped to the spec, do not provide the "spec" prefix as the are not stored with it. 

```yaml
  create_user:
    path: "/users"
    method: "post"
    expectations:
    - variables:
        name: "John"
        email: "john@example.com"
      store_as: "created_user"
      expect:
        status: 200

  show_user:
    path: "/users/:id"
    query:
      id: store.created_user.response.id
    - expect:
        status: 200
  ```

## Changelog

### Added
- Added `Attribute::Store` for accessing stored test data

### Changed
- Cleaned up `Attribute.from_string` 
