### PR TITLE
feat - Add callback support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `match_status` for seeing the resolved matcher for status
   - `match_json` for seeing the resolved matcher for json
 - Added more integration tests for better coverage
+- Added support for callbacks
+- Define callbacks at configuration level or module level:
+  ```ruby
+  # Configuration level
+  SpecForge.configure do |config|
+    config.register_callback("callback_name") { |context| }
+    # These are aliases
+    # config.define_callback("callback_name") { |context| }
+    # config.callback("callback_name") { |context| }
+  end
+
+  # Module level (no aliases)
+  SpecForge.register_callback("callback_name") { |context| }
+  ```
+- Use callbacks in YAML:
+  ```yaml
+  global:
+    callbacks:
+      - before: prepare_database_state
+        after: cleanup_database_state
+  ```
 
 ### Changed
 
@@ -99,6 +120,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Now: Each key at the root level is checked individually, giving more precise error messages when tests fail
   - Nested hashes still use the `include` matcher for flexibility
 - Adjusted `Attribute::Matcher` to accept either `matcher` or `matchers` namespace
+- Changed empty array matcher from using `contain_exactly` to `eq([])`
+- Changed empty hash matcher from using `include` to `eq({})`
+- Changed `forge_and` description from "matches all of:" to "match all:"
 
 ### Removed
 

--- a/lib/spec_forge.rb
+++ b/lib/spec_forge.rb
@@ -144,6 +144,10 @@ module SpecForge
   def self.context
     @context ||= Context.new
   end
+
+  def self.register_callback(name, &)
+    Callbacks.register(name, &)
+  end
 end
 
 require_relative "spec_forge/attribute"

--- a/lib/spec_forge.rb
+++ b/lib/spec_forge.rb
@@ -44,109 +44,127 @@ require "yaml"
 #   SpecForge.run(file_name: "users", spec_name: "create_user")
 #
 module SpecForge
-  #
-  # Loads all factories and specs and runs the tests with optional filtering
-  #
-  # This is the main entry point for running SpecForge tests. It loads the
-  # forge_helper.rb file if it exists, configures the environment, loads
-  # factories and specs, and runs the tests through RSpec.
-  #
-  # @param file_name [String, nil] Optional name of spec file to run
-  # @param spec_name [String, nil] Optional name of spec to run
-  # @param expectation_name [String, nil] Optional name of expectation to run
-  #
-  def self.run(file_name: nil, spec_name: nil, expectation_name: nil)
-    # Load spec_helper.rb
-    forge_helper = SpecForge.forge_path.join("forge_helper.rb")
-    require_relative forge_helper if File.exist?(forge_helper)
+  class << self
+    #
+    # Loads all factories and specs and runs the tests with optional filtering
+    #
+    # This is the main entry point for running SpecForge tests. It loads the
+    # forge_helper.rb file if it exists, configures the environment, loads
+    # factories and specs, and runs the tests through RSpec.
+    #
+    # @param file_name [String, nil] Optional name of spec file to run
+    # @param spec_name [String, nil] Optional name of spec to run
+    # @param expectation_name [String, nil] Optional name of expectation to run
+    #
+    def run(file_name: nil, spec_name: nil, expectation_name: nil)
+      # Load spec_helper.rb
+      forge_helper = SpecForge.forge_path.join("forge_helper.rb")
+      require_relative forge_helper if File.exist?(forge_helper)
 
-    # Validate in case anything was changed
-    configuration.validate
+      # Validate in case anything was changed
+      configuration.validate
 
-    # Load factories
-    Factory.load_and_register
+      # Load factories
+      Factory.load_and_register
 
-    # Load the specs from their files and create forges from them
-    forges = Loader.load_from_files.map { |f| Forge.new(*f) }
+      # Load the specs from their files and create forges from them
+      forges = Loader.load_from_files.map { |f| Forge.new(*f) }
 
-    # Filter out the specs and expectations
-    forges = Filter.apply(forges, file_name:, spec_name:, expectation_name:)
+      # Filter out the specs and expectations
+      forges = Filter.apply(forges, file_name:, spec_name:, expectation_name:)
 
-    # Define and run everything
-    Runner.define(forges)
-    Runner.run
-  end
-
-  #
-  # Returns the directory root for the working directory
-  #
-  # @return [Pathname] The root directory path
-  #
-  def self.root
-    @root ||= Pathname.pwd
-  end
-
-  #
-  # Returns SpecForge's working directory
-  #
-  # @return [Pathname] The spec_forge directory path
-  #
-  def self.forge_path
-    @forge_path ||= root.join("spec_forge")
-  end
-
-  #
-  # Returns SpecForge's configuration
-  #
-  # @return [Configuration] The current configuration
-  #
-  def self.configuration
-    @configuration ||= Configuration.new
-  end
-
-  #
-  # Yields SpecForge's configuration to a block for modification
-  #
-  # @yield [config] Block that receives the configuration object
-  # @yieldparam config [Configuration] The configuration to modify
-  #
-  # @return [Configuration] The updated configuration
-  #
-  def self.configure(&block)
-    block&.call(configuration)
-    configuration
-  end
-
-  #
-  # Returns a backtrace cleaner configured for SpecForge
-  #
-  # Creates and configures an ActiveSupport::BacktraceCleaner to improve
-  # error messages by removing unnecessary lines and root paths.
-  #
-  # @return [ActiveSupport::BacktraceCleaner] The configured backtrace cleaner
-  #
-  def self.backtrace_cleaner
-    @backtrace_cleaner ||= begin
-      root = "#{SpecForge.root}/"
-
-      cleaner = ActiveSupport::BacktraceCleaner.new
-      cleaner.add_filter { |line| line.delete_prefix(root) }
-      cleaner.add_silencer { |line| /rubygems|backtrace_cleaner/.match?(line) }
-      cleaner
+      # Define and run everything
+      Runner.define(forges)
+      Runner.run
     end
-  end
 
-  #
-  # Returns the current execution context
-  #
-  # @return [Context] The current context object
-  #
-  def self.context
-    @context ||= Context.new
-  end
+    #
+    # Returns the directory root for the working directory
+    #
+    # @return [Pathname] The root directory path
+    #
+    def root
+      @root ||= Pathname.pwd
+    end
 
-  def self.register_callback(name, &)
-    Callbacks.register(name, &)
+    #
+    # Returns SpecForge's working directory
+    #
+    # @return [Pathname] The spec_forge directory path
+    #
+    def forge_path
+      @forge_path ||= root.join("spec_forge")
+    end
+
+    #
+    # Returns SpecForge's configuration
+    #
+    # @return [Configuration] The current configuration
+    #
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    #
+    # Yields SpecForge's configuration to a block for modification
+    #
+    # @yield [config] Block that receives the configuration object
+    # @yieldparam config [Configuration] The configuration to modify
+    #
+    # @return [Configuration] The updated configuration
+    #
+    def configure(&block)
+      block&.call(configuration)
+      configuration
+    end
+
+    #
+    # Returns a backtrace cleaner configured for SpecForge
+    #
+    # Creates and configures an ActiveSupport::BacktraceCleaner to improve
+    # error messages by removing unnecessary lines and root paths.
+    #
+    # @return [ActiveSupport::BacktraceCleaner] The configured backtrace cleaner
+    #
+    def backtrace_cleaner
+      @backtrace_cleaner ||= begin
+        root = "#{SpecForge.root}/"
+
+        cleaner = ActiveSupport::BacktraceCleaner.new
+        cleaner.add_filter { |line| line.delete_prefix(root) }
+        cleaner.add_silencer { |line| /rubygems|backtrace_cleaner/.match?(line) }
+        cleaner
+      end
+    end
+
+    #
+    # Returns the current execution context
+    #
+    # @return [Context] The current context object
+    #
+    def context
+      @context ||= Context.new
+    end
+
+    #
+    # Registers a callback for a specific test lifecycle event
+    # Allows custom code execution at specific points during test execution
+    #
+    # @param name [Symbol, String] A unique identifier for this callback
+    # @yield A block to execute when the callback is triggered
+    # @yieldparam context [Object] An object containing context-specific state data, depending
+    #   on which hook the callback is triggered from.
+    #
+    # @return [Proc] The registered callback
+    #
+    # @example Registering a custom debug handler
+    #   SpecForge.register_callback(:clean_database) do |context|
+    #     DatabaseCleaner.clean
+    #   end
+    #
+    def register_callback(name, &)
+      Callbacks.register(name, &)
+    end
   end
 end
 

--- a/lib/spec_forge.rb
+++ b/lib/spec_forge.rb
@@ -148,6 +148,7 @@ end
 
 require_relative "spec_forge/attribute"
 require_relative "spec_forge/backtrace_formatter"
+require_relative "spec_forge/callbacks"
 require_relative "spec_forge/cli"
 require_relative "spec_forge/configuration"
 require_relative "spec_forge/context"

--- a/lib/spec_forge/attribute.rb
+++ b/lib/spec_forge/attribute.rb
@@ -255,10 +255,20 @@ module SpecForge
       case resolved
       when Array, ArrayLike
         resolved_array = resolved.map(&resolve_as_matcher_proc)
-        methods.contain_exactly(*resolved_array)
+
+        if resolved_array.size > 0
+          methods.contain_exactly(*resolved_array)
+        else
+          methods.eq([])
+        end
       when Hash, HashLike
         resolved_hash = resolved.transform_values(&resolve_as_matcher_proc).stringify_keys
-        methods.include(**resolved_hash)
+
+        if resolved_hash.size > 0
+          methods.include(**resolved_hash)
+        else
+          methods.eq({})
+        end
       when Attribute::Matcher, Regexp
         methods.match(resolved)
       when RSpec::Matchers::BuiltIn::BaseMatcher,

--- a/lib/spec_forge/callbacks.rb
+++ b/lib/spec_forge/callbacks.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SpecForge
+  class Callbacks < Hash
+    include Singleton
+
+    def self.register(name, &block)
+      raise ArgumentError, "A block must be provided" unless block.is_a?(Proc)
+
+      if instance.key?(name)
+        warn("Callback #{name.in_quotes} is already registered. It will be overwritten")
+      end
+
+      instance[name] = block
+    end
+  end
+end

--- a/lib/spec_forge/callbacks.rb
+++ b/lib/spec_forge/callbacks.rb
@@ -1,10 +1,31 @@
 # frozen_string_literal: true
 
 module SpecForge
+  #
+  # Manages user-defined callbacks for test lifecycle events
+  #
+  # This singleton class stores and executes callback functions that
+  # users can register to run at specific points in the test lifecycle.
+  # Each callback receives a context object containing relevant state
+  # information for that point in execution.
+  #
+  # @example Registering and using a callback
+  #   SpecForge::Callbacks.register(:my_callback) do |context|
+  #     puts "Running test: #{context.expectation_name}"
+  #   end
+  #
   class Callbacks < Hash
     include Singleton
 
     class << self
+      #
+      # Registers a new callback for a specific event
+      #
+      # @param name [String, Symbol] The name of the callback event
+      # @param block [Proc] The callback function to execute
+      #
+      # @raise [ArgumentError] If no block is provided
+      #
       def register(name, &block)
         raise ArgumentError, "A block must be provided" unless block.is_a?(Proc)
 
@@ -15,19 +36,39 @@ module SpecForge
         instance[name.to_s] = block
       end
 
+      #
+      # Checks if a callback is registered for the given event
+      #
+      # @param name [String, Symbol] The name of the callback event
+      #
+      # @return [Boolean] True if the callback exists
+      #
       def registered?(name)
         instance.key?(name.to_s)
       end
 
+      #
+      # Returns all registered callback names
+      #
+      # @return [Array<String>] List of registered callback names
+      #
       def registered_names
         instance.keys
       end
 
-      def run_callback(name, arguments = [])
+      #
+      # Executes the callback for the specified event
+      #
+      # @param name [String, Symbol] The name of the callback event to run
+      # @param context [Object] Context object containing event state
+      #
+      # @raise [ArgumentError] If the callback does not exist
+      #
+      def run_callback(name, context)
         callback = instance[name.to_s]
         raise ArgumentError, "Callback #{name.in_quotes} is not defined" if callback.nil?
 
-        callback.call(*arguments)
+        callback.call(context)
       end
     end
   end

--- a/lib/spec_forge/callbacks.rb
+++ b/lib/spec_forge/callbacks.rb
@@ -68,7 +68,11 @@ module SpecForge
         callback = instance[name.to_s]
         raise ArgumentError, "Callback #{name.in_quotes} is not defined" if callback.nil?
 
-        callback.call(context)
+        if callback.arity == 0
+          callback.call
+        else
+          callback.call(context)
+        end
       end
     end
   end

--- a/lib/spec_forge/callbacks.rb
+++ b/lib/spec_forge/callbacks.rb
@@ -57,14 +57,14 @@ module SpecForge
       end
 
       #
-      # Executes the callback for the specified event
+      # Executes a named callback with the provided context
       #
-      # @param name [String, Symbol] The name of the callback event to run
-      # @param context [Object] Context object containing event state
+      # @param name [String, Symbol] The name of the callback to run
+      # @param context [Object] Context object containing state data
       #
-      # @raise [ArgumentError] If the callback does not exist
+      # @raise [ArgumentError] If the callback is not registered
       #
-      def run_callback(name, context)
+      def run(name, context)
         callback = instance[name.to_s]
         raise ArgumentError, "Callback #{name.in_quotes} is not defined" if callback.nil?
 

--- a/lib/spec_forge/callbacks.rb
+++ b/lib/spec_forge/callbacks.rb
@@ -4,14 +4,31 @@ module SpecForge
   class Callbacks < Hash
     include Singleton
 
-    def self.register(name, &block)
-      raise ArgumentError, "A block must be provided" unless block.is_a?(Proc)
+    class << self
+      def register(name, &block)
+        raise ArgumentError, "A block must be provided" unless block.is_a?(Proc)
 
-      if instance.key?(name)
-        warn("Callback #{name.in_quotes} is already registered. It will be overwritten")
+        if registered?(name)
+          warn("Callback #{name.in_quotes} is already registered. It will be overwritten")
+        end
+
+        instance[name.to_s] = block
       end
 
-      instance[name] = block
+      def registered?(name)
+        instance.key?(name.to_s)
+      end
+
+      def registered_names
+        instance.keys
+      end
+
+      def run_callback(name, arguments = [])
+        callback = instance[name.to_s]
+        raise ArgumentError, "Callback #{name.in_quotes} is not defined" if callback.nil?
+
+        callback.call(*arguments)
+      end
     end
   end
 end

--- a/lib/spec_forge/context.rb
+++ b/lib/spec_forge/context.rb
@@ -30,6 +30,7 @@ module SpecForge
   end
 end
 
+require_relative "context/callbacks"
 require_relative "context/global"
 require_relative "context/store"
 require_relative "context/variables"

--- a/lib/spec_forge/context/callbacks.rb
+++ b/lib/spec_forge/context/callbacks.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module SpecForge
+  class Context
+    #
+    # Manages user-defined callbacks grouped by lifecycle hook
+    #
+    # This class collects and organizes callbacks by their hook type
+    # (before_file, after_each, etc.) to support the test lifecycle.
+    # It ensures callbacks are properly categorized for execution.
+    #
+    # @example Creating callback groups
+    #   callbacks = Context::Callbacks.new([
+    #     {before_file: "setup_environment"},
+    #     {after_each: "log_test_result"}
+    #   ])
+    #
+    class Callbacks
+      #
+      # Creates a new callbacks collection
+      #
+      # @param callback_array [Array] Optional initial callbacks to register
+      #
+      # @return [Callbacks] A new callbacks collection
+      #
+      def initialize(callback_array = [])
+        set(callback_array)
+      end
+
+      #
+      # Updates the callbacks collection
+      #
+      # @param callback_array [Array] New callbacks to register
+      #
+      # @return [self]
+      #
+      def set(callback_array)
+        @inner = organize_callbacks_by_hook(callback_array)
+        self
+      end
+
+      #
+      # Returns the hash representation of callbacks
+      #
+      # @return [Hash] Callbacks organized by hook type
+      #
+      def to_h
+        @inner
+      end
+
+      private
+
+      #
+      # Organizes callbacks from an array to hash structure by hook type
+      # Groups callbacks like before_file, after_each, etc. for easier lookup
+      #
+      # @param callback_array [Array] The array of callbacks
+      #
+      # @return [Hash] Callbacks indexed by hook type
+      #
+      # @private
+      #
+      def organize_callbacks_by_hook(callback_array)
+        groups = Hash.new { |h, k| h[k] = Set.new }
+
+        callback_array.each_with_object(groups) do |callbacks, groups|
+          callbacks.each do |hook, name|
+            next if name.blank?
+
+            groups[hook].add(name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/spec_forge/context/callbacks.rb
+++ b/lib/spec_forge/context/callbacks.rb
@@ -48,6 +48,22 @@ module SpecForge
         @inner
       end
 
+      #
+      # Executes all registered callbacks for a specific lifecycle hook
+      #
+      # @param hook_name [String, Symbol] The lifecycle hook (before_file, after_each, etc.)
+      # @param context [Hash] State data that will be converted to a structured object
+      #   and passed to callbacks
+      #
+      #
+      def run(hook_name, context = {})
+        context = context.to_istruct
+
+        @inner[hook_name].each do |callback_name|
+          SpecForge::Callbacks.run(callback_name, context)
+        end
+      end
+
       private
 
       #

--- a/lib/spec_forge/context/callbacks.rb
+++ b/lib/spec_forge/context/callbacks.rb
@@ -55,7 +55,6 @@ module SpecForge
       # @param context [Hash] State data that will be converted to a structured object
       #   and passed to callbacks
       #
-      #
       def run(hook_name, context = {})
         context = context.to_istruct
 

--- a/lib/spec_forge/context/global.rb
+++ b/lib/spec_forge/context/global.rb
@@ -25,26 +25,34 @@ module SpecForge
       # @return [Context::Variables] The container for global variables
       attr_reader :variables
 
+      # @return [Context::Callbacks] The container for callbacks
+      attr_reader :callbacks
+
       #
       # Creates a new Global context instance
       #
       # @param variables [Hash<Symbol, Object>] A hash of variable names and values
+      # @param callbacks [Array<Hash<Symbol, String>>] An array of callback hooks
       #
       # @return [Global] The new Global instance
       #
-      def initialize(variables: {})
+      def initialize(variables: {}, callbacks: [])
         @variables = Variables.new(base: variables)
+        @callbacks = Callbacks.new(callbacks)
       end
 
       #
       # Sets the global variables
       #
       # @param variables [Hash<Symbol, Object>] A hash of variable names and values
+      # @param callbacks [Array<Hash<Symbol, String>>] An array of callback hooks
       #
       # @return [self]
       #
-      def set(variables:)
+      def set(variables:, callbacks: [])
         @variables.set(base: variables)
+        @callbacks.set(callbacks)
+
         self
       end
 
@@ -55,7 +63,8 @@ module SpecForge
       #
       def to_h
         {
-          variables: variables.to_h
+          variables: variables.to_h,
+          callbacks: callbacks.to_h
         }
       end
     end

--- a/lib/spec_forge/context/global.rb
+++ b/lib/spec_forge/context/global.rb
@@ -49,7 +49,7 @@ module SpecForge
       #
       # @return [self]
       #
-      def set(variables:, callbacks: [])
+      def set(variables: {}, callbacks: [])
         @variables.set(base: variables)
         @callbacks.set(callbacks)
 

--- a/lib/spec_forge/context/store.rb
+++ b/lib/spec_forge/context/store.rb
@@ -104,10 +104,12 @@ module SpecForge
       #
       # @param id [String, Symbol] The identifier to store the entry under
       #
-      # @return [Entry] The newly created entry
+      # @return [self]
       #
       def set(id, **)
         @inner[id] = Entry.new(**)
+
+        self
       end
 
       #

--- a/lib/spec_forge/context/store.rb
+++ b/lib/spec_forge/context/store.rb
@@ -123,6 +123,15 @@ module SpecForge
       def clear_specs
         @inner.delete_if { |_k, v| v.scope == :spec }
       end
+
+      #
+      # Returns a hash representation of store
+      #
+      # @return [Hash]
+      #
+      def to_h
+        @inner
+      end
     end
   end
 end

--- a/lib/spec_forge/error.rb
+++ b/lib/spec_forge/error.rb
@@ -256,5 +256,33 @@ module SpecForge
         )
       end
     end
+
+    #
+    # Raised when a callback is referenced in config but hasn't been defined
+    #
+    class UndefinedCallbackError < Error
+      def initialize(callback_name, available_callbacks = [])
+        message = "The callback #{callback_name.in_quotes} was referenced but hasn't been defined."
+
+        message +=
+          if available_callbacks.any?
+            <<~STR.chomp
+
+              Available callbacks are: #{available_callbacks.join_map(", ", &:in_quotes)}
+            STR
+          else
+            <<~STR.chomp
+
+              No callbacks have been defined yet. Register callbacks with:
+
+                SpecForge.register_callback(:#{callback_name}) do |context|
+                  # Your callback code
+                end
+            STR
+          end
+
+        super(message)
+      end
+    end
   end
 end

--- a/lib/spec_forge/matchers.rb
+++ b/lib/spec_forge/matchers.rb
@@ -90,7 +90,7 @@ module SpecForge
         end
 
         description do
-          "matches all of: " + matchers.join_map(", ", &:description)
+          "match all: " + matchers.join_map(", ", &:description)
         end
       end
     end

--- a/lib/spec_forge/normalizer.rb
+++ b/lib/spec_forge/normalizer.rb
@@ -65,7 +65,15 @@ module SpecForge
         default: false,
         aliases: %i[pry breakpoint]
       },
-      callback: {type: [String, NilClass]}
+      callback: {
+        type: [String, NilClass],
+        validator: lambda do |value|
+          return if value.blank?
+          return if SpecForge::Callbacks.registered?(value)
+
+          raise Error::UndefinedCallbackError.new(value, SpecForge::Callbacks.registered_names)
+        end
+      }
     }.freeze
 
     #

--- a/lib/spec_forge/normalizer.rb
+++ b/lib/spec_forge/normalizer.rb
@@ -365,7 +365,7 @@ module SpecForge
         structure[:validator]&.call(value)
 
         if (substructure = structure[:structure])
-          value = normalize_substructure(label, value, substructure, errors)
+          value = normalize_substructure("index #{index} of #{label}", value, substructure, errors)
         end
 
         output << value

--- a/lib/spec_forge/normalizer.rb
+++ b/lib/spec_forge/normalizer.rb
@@ -167,7 +167,12 @@ module SpecForge
     # @return [Array<Hash, Set>] The normalized data and any errors
     #
     def normalize
-      normalize_to_structure
+      case input
+      when Hash
+        normalize_hash
+      when Array
+        normalize_array
+      end
     end
 
     #
@@ -198,13 +203,12 @@ module SpecForge
     #
     # @private
     #
-    def normalize_to_structure
+    def normalize_hash
       output, errors = {}, Set.new
 
       structure.each do |key, attribute|
         type_class = attribute[:type]
         aliases = attribute[:aliases] || []
-        sub_structure = attribute[:structure]
         default = attribute[:default]
         required = !attribute.key?(:default)
 
@@ -235,19 +239,10 @@ module SpecForge
         # Call the validator if it has one
         attribute[:validator]&.call(value)
 
-        # Validate any sub structures
-        value =
-          case [value.class, sub_structure.class]
-          when [Hash, Hash]
-            new_value, new_errors = self.class
-              .new(label, value, structure: sub_structure)
-              .normalize
-
-            errors += new_errors if new_errors.size > 0
-            new_value
-          else
-            value
-          end
+        # Normalize any sub structures
+        if (substructure = attribute[:structure])
+          value = normalize_substructure(value, substructure, errors)
+        end
 
         # Store
         output[key] = value
@@ -288,6 +283,42 @@ module SpecForge
       else
         value.is_a?(expected_type)
       end
+    end
+
+    def normalize_substructure(value, substructure, errors)
+      return value unless value.is_a?(Hash) || value.is_a?(Array)
+
+      new_value, new_errors = self.class
+        .new(label, value, structure: substructure)
+        .normalize
+
+      errors.merge(new_errors) if new_errors.size > 0
+      new_value
+    end
+
+    def normalize_array
+      output, errors = [], Set.new
+
+      input.each_with_index do |value, index|
+        type_class = structure[:type]
+
+        if !valid_class?(value, type_class)
+          raise Error::InvalidTypeError.new(value, type_class, for: "index #{index} in #{label}")
+        end
+
+        # Call the validator if it has one
+        structure[:validator]&.call(value)
+
+        if (substructure = structure[:structure])
+          value = normalize_substructure(value, substructure, errors)
+        end
+
+        output << value
+      rescue => e
+        errors << e
+      end
+
+      [output, errors]
     end
   end
 end

--- a/lib/spec_forge/normalizer.rb
+++ b/lib/spec_forge/normalizer.rb
@@ -64,7 +64,8 @@ module SpecForge
         type: [TrueClass, FalseClass],
         default: false,
         aliases: %i[pry breakpoint]
-      }
+      },
+      callback: {type: [String, NilClass]}
     }.freeze
 
     #
@@ -220,14 +221,7 @@ module SpecForge
 
         # Type + existence check
         if !valid_class?(value, type_class)
-          for_context = "\"#{key}\""
-
-          if aliases.size > 0
-            aliases = aliases.join_map(", ") { |a| a.to_s.in_quotes }
-            for_context += " (aliases #{aliases})"
-          end
-
-          for_context += " in #{label}"
+          for_context = generate_error_label(key, aliases)
 
           if (line_number = input[:line_number])
             for_context += " (line #{line_number})"
@@ -241,7 +235,8 @@ module SpecForge
 
         # Normalize any sub structures
         if (substructure = attribute[:structure])
-          value = normalize_substructure(value, substructure, errors)
+          new_label = generate_error_label(key, aliases)
+          value = normalize_substructure(new_label, value, substructure, errors)
         end
 
         # Store
@@ -285,17 +280,77 @@ module SpecForge
       end
     end
 
-    def normalize_substructure(value, substructure, errors)
+    #
+    # Generates an error label with information about the key and its aliases
+    #
+    # Creates a descriptive label for error messages that includes the key name,
+    # any aliases it may have, and the context in which it appears.
+    #
+    # @param key [Symbol, String] The key that caused the error
+    # @param aliases [Array<Symbol, String>] Any aliases for the key
+    #
+    # @return [String] A formatted error label
+    #
+    # @example
+    #   generate_error_label(:user_id, [:id, :uid])
+    #   # => "\"user_id\" (aliases \"id\", \"uid\") in user config"
+    #
+    def generate_error_label(key, aliases)
+      error_label = key.to_s.in_quotes
+
+      if aliases.size > 0
+        aliases = aliases.join_map(", ") { |a| a.to_s.in_quotes }
+        error_label += " (aliases #{aliases})"
+      end
+
+      error_label + " in #{label}"
+    end
+
+    #
+    # Normalizes an array according to its structure definition
+    #
+    # Processes each element in the input array, validating its type and
+    # recursively normalizing any nested structures.
+    #
+    # @return [Array<Object, Set>] A two-element array containing:
+    #   1. The normalized array
+    #   2. A set of any errors encountered during normalization
+    #
+    # @example
+    #   input = [1, "string", 3]
+    #   structure = {type: Numeric}
+    #   normalize_array # => [[1, 3], #<Set: {Error}>]
+    #
+    def normalize_substructure(new_label, value, substructure, errors)
       return value unless value.is_a?(Hash) || value.is_a?(Array)
 
       new_value, new_errors = self.class
-        .new(label, value, structure: substructure)
+        .new(new_label, value, structure: substructure)
         .normalize
 
       errors.merge(new_errors) if new_errors.size > 0
       new_value
     end
 
+    #
+    # Normalizes a nested substructure within a parent structure
+    #
+    # Recursively processes nested Hash or Array structures according to
+    # their structure definitions, collecting any validation errors.
+    #
+    # @param new_label [String] The label to use for error messages
+    # @param value [Hash, Array] The nested structure to normalize
+    # @param substructure [Hash] The structure definition for validation
+    # @param errors [Set] A set to collect any encountered errors
+    #
+    # @return [Hash, Array] The normalized substructure
+    #
+    # @example
+    #   value = {name: "Test", age: "25"}
+    #   substructure = {name: {type: String}, age: {type: Integer}}
+    #   normalize_substructure("user", value, substructure, Set.new)
+    #   # => {name: "Test", age: 25}
+    #
     def normalize_array
       output, errors = [], Set.new
 
@@ -303,14 +358,14 @@ module SpecForge
         type_class = structure[:type]
 
         if !valid_class?(value, type_class)
-          raise Error::InvalidTypeError.new(value, type_class, for: "index #{index} in #{label}")
+          raise Error::InvalidTypeError.new(value, type_class, for: "index #{index} of #{label}")
         end
 
         # Call the validator if it has one
         structure[:validator]&.call(value)
 
         if (substructure = structure[:structure])
-          value = normalize_substructure(value, substructure, errors)
+          value = normalize_substructure(label, value, substructure, errors)
         end
 
         output << value

--- a/lib/spec_forge/normalizer/global_context.rb
+++ b/lib/spec_forge/normalizer/global_context.rb
@@ -20,7 +20,24 @@ module SpecForge
       # @return [Hash] Configuration attribute validation rules
       #
       STRUCTURE = {
-        variables: Normalizer::SHARED_ATTRIBUTES[:variables]
+        variables: Normalizer::SHARED_ATTRIBUTES[:variables],
+        callbacks: {
+          type: Array,
+          default: [],
+          structure: {
+            type: Hash,
+            default: {},
+            structure: {
+              before_file: Normalizer::SHARED_ATTRIBUTES[:callback],
+              before_spec: Normalizer::SHARED_ATTRIBUTES[:callback],
+              before_each: Normalizer::SHARED_ATTRIBUTES[:callback].merge(aliases: %i[before]),
+              around_each: Normalizer::SHARED_ATTRIBUTES[:callback].merge(aliases: %i[around]),
+              after_each: Normalizer::SHARED_ATTRIBUTES[:callback].merge(aliases: %i[after]),
+              after_spec: Normalizer::SHARED_ATTRIBUTES[:callback],
+              after_file: Normalizer::SHARED_ATTRIBUTES[:callback]
+            }
+          }
+        }
       }.freeze
     end
 

--- a/lib/spec_forge/runner.rb
+++ b/lib/spec_forge/runner.rb
@@ -155,16 +155,17 @@ module SpecForge
       private
 
       def prepare_for_run
+        # Stores the current examples context, useful for callbacks
+        @current_example_context = nil
+
         # Allows modifying the error backtrace reporting within rspec
         RSpec.configuration.instance_variable_set(:@backtrace_formatter, BacktraceFormatter)
 
-        # Listen for when a example passes or fails
+        # Listen for passed/failed events to trigger the "after_each" callback
         RSpec.configuration.reporter.register_listener(
           Listener.instance,
           :example_passed, :example_failed
         )
-
-        @current_example_context = nil
       end
     end
   end

--- a/lib/spec_forge/runner/callbacks.rb
+++ b/lib/spec_forge/runner/callbacks.rb
@@ -33,7 +33,7 @@ module SpecForge
           SpecForge.context.store.clear
 
           # Run the user defined callbacks
-          SpecForge.context.global.run_callbacks(:before_file, file_context(forge))
+          SpecForge.context.global.callbacks.run(:before_file, file_context(forge))
         end
 
         #
@@ -56,7 +56,7 @@ module SpecForge
           SpecForge.context.store.clear_specs
 
           # Run the user defined callbacks
-          SpecForge.context.global.run_callbacks(:before_spec, spec_context(forge, spec))
+          SpecForge.context.global.callbacks.run(:before_spec, spec_context(forge, spec))
         end
 
         #
@@ -68,7 +68,7 @@ module SpecForge
         # @param forge [SpecForge::Forge] The forge being tested
         # @param spec [SpecForge::Spec] The spec being tested
         # @param expectation [SpecForge::Spec::Expectation] The expectation about to be evaluated
-        # @param example_group [RSpec::ExampleGroups] The current running example group
+        # @param example_group [RSpec::Core::ExampleGroup] The current running example group
         # @param example [RSpec::Core::Example] The current example
         #
         def before_expectation(forge, spec, expectation, example_group, example)
@@ -82,7 +82,7 @@ module SpecForge
           SpecForge.context.variables.resolved
 
           # Run the user defined callbacks
-          SpecForge.context.global.run_callbacks(
+          SpecForge.context.global.callbacks.run(
             :before_each,
             expectation_context(forge, spec, expectation, example_group, example)
           )
@@ -97,7 +97,7 @@ module SpecForge
         # @param forge [SpecForge::Forge] The forge being tested
         # @param spec [SpecForge::Spec] The spec being tested
         # @param expectation [SpecForge::Spec::Expectation] The expectation being evaluated
-        # @param example_group [RSpec::ExampleGroups] The current running example group
+        # @param example_group [RSpec::Core::ExampleGroup] The current running example group
         #
         def on_debug(forge, spec, expectation, example_group)
           DebugProxy.new(forge, spec, expectation, example_group).call
@@ -111,7 +111,7 @@ module SpecForge
         # @param forge [SpecForge::Forge] The forge being tested
         # @param spec [SpecForge::Spec] The spec being tested
         # @param expectation [SpecForge::Spec::Expectation] The expectation that was evaluated
-        # @param example_group [RSpec::ExampleGroups] The current running example group
+        # @param example_group [RSpec::Core::ExampleGroup] The current running example group
         # @param example [RSpec::Core::Example] The current example
         #
         def after_expectation(forge, spec, expectation, example_group, example)
@@ -119,7 +119,7 @@ module SpecForge
           store_result(expectation, example_group) if expectation.store_as?
 
           # Run the user defined callbacks
-          SpecForge.context.global.run_callbacks(
+          SpecForge.context.global.callbacks.run(
             :after_each,
             expectation_context(forge, spec, expectation, example_group, example)
           )
@@ -133,7 +133,7 @@ module SpecForge
         #
         def after_spec(forge, spec)
           # Run the user defined callbacks
-          SpecForge.context.global.run_callbacks(:after_spec, spec_context(forge, spec))
+          SpecForge.context.global.callbacks.run(:after_spec, spec_context(forge, spec))
         end
 
         #
@@ -143,7 +143,7 @@ module SpecForge
         #
         def after_file(forge)
           # Run the user defined callbacks
-          SpecForge.context.global.run_callbacks(:after_file, file_context(forge))
+          SpecForge.context.global.callbacks.run(:after_file, file_context(forge))
         end
 
         private
@@ -156,7 +156,7 @@ module SpecForge
         # and normalizes the ID by removing scope prefixes.
         #
         # @param expectation [SpecForge::Spec::Expectation] The expectation that is being stored
-        # @param example_group [RSpec::ExampleGroups] The current running example group
+        # @param example_group [RSpec::Core::ExampleGroup] The current running example group
         #
         def store_result(expectation, example_group)
           id = expectation.store_as
@@ -228,7 +228,7 @@ module SpecForge
         # @param forge [SpecForge::Forge] The forge being tested
         # @param spec [SpecForge::Spec] The spec being tested
         # @param expectation [SpecForge::Spec::Expectation] The expectation being evaluated
-        # @param example_group [RSpec::ExampleGroups] The current running example group
+        # @param example_group [RSpec::Core::ExampleGroup] The current running example group
         # @param example [RSpec::Core::Example] The current example
         #
         # @return [Hash] Context with file, spec and expectation information

--- a/lib/spec_forge/runner/debug_proxy.rb
+++ b/lib/spec_forge/runner/debug_proxy.rb
@@ -62,7 +62,7 @@ module SpecForge
       # @param forge [SpecForge::Forge] The forge being tested
       # @param spec [SpecForge::Spec] The spec being tested
       # @param expectation [SpecForge::Spec::Expectation] The expectation being tested
-      # @param example_group [RSpec::ExampleGroups] The current example group
+      # @param example_group [RSpec::Core::ExampleGroup] The current example group
       #
       # @return [SpecForge::Runner::DebugProxy]
       #

--- a/lib/spec_forge/runner/debug_proxy.rb
+++ b/lib/spec_forge/runner/debug_proxy.rb
@@ -62,7 +62,7 @@ module SpecForge
       # @param forge [SpecForge::Forge] The forge being tested
       # @param spec [SpecForge::Spec] The spec being tested
       # @param expectation [SpecForge::Spec::Expectation] The expectation being tested
-      # @param example_group [RSpec::Core::ExampleGroup] The current example group
+      # @param example_group [RSpec::ExampleGroups] The current example group
       #
       # @return [SpecForge::Runner::DebugProxy]
       #
@@ -116,7 +116,7 @@ module SpecForge
           Helper objects:
           - http_client: The HTTP client used for the request
           - request_data: Raw request configuration data
-          - example_group: Current RSpec example context
+          - example_group: Current RSpec example group
           - example: Current RSpec example
           - forge: Current file being tested
 

--- a/lib/spec_forge/runner/listener.rb
+++ b/lib/spec_forge/runner/listener.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module SpecForge
+  class Runner
+    #
+    # Listens for RSpec test result notifications and triggers the appropriate callbacks
+    #
+    # This singleton class receives notifications from RSpec when examples pass or fail,
+    # retrieves the current test context, and triggers the appropriate SpecForge callbacks.
+    # It acts as a bridge between RSpec's notification system and SpecForge's callback system.
+    #
+    class Listener
+      include Singleton
+
+      #
+      # Handles RSpec notifications for passing examples
+      #
+      # @param notification [RSpec::Core::Notifications::ExampleNotification]
+      #   The notification object
+      #
+      def example_passed(notification)
+        example = notification.example
+        trigger_callback(example)
+      end
+
+      #
+      # Handles RSpec notifications for failing examples
+      #
+      # @param notification [RSpec::Core::Notifications::FailedExampleNotification]
+      #   The notification object
+      #
+      def example_failed(notification)
+        example = notification.example
+        trigger_callback(example)
+      end
+
+      #
+      # Triggers the appropriate SpecForge callback with the complete context
+      #
+      # Retrieves the current example context stored during the RSpec execution,
+      # adds the example object, and passes everything to the appropriate callback.
+      #
+      # @param example [RSpec::Core::Example] The example that was run
+      #
+      # @private
+      #
+      def trigger_callback(example)
+        # {forge:, spec:, expectation:, example_group:}
+        context = Runner.current_example_context
+        context[:example] = example
+
+        Runner::Callbacks.after_expectation(*context.values)
+      end
+    end
+  end
+end

--- a/lib/spec_forge/runner/metadata.rb
+++ b/lib/spec_forge/runner/metadata.rb
@@ -23,7 +23,7 @@ module SpecForge
         #
         # @param spec [SpecForge::Spec] The spec being tested
         # @param expectation [SpecForge::Spec::Expectation] The expectation being evaluated
-        # @param example_group [RSpec::ExampleGroups] The example group to update
+        # @param example_group [RSpec::Core::ExampleGroup] The example group to update
         #
         def set_for_group(spec, expectation, example_group)
           metadata = {

--- a/lib/spec_forge/runner/metadata.rb
+++ b/lib/spec_forge/runner/metadata.rb
@@ -23,7 +23,7 @@ module SpecForge
         #
         # @param spec [SpecForge::Spec] The spec being tested
         # @param expectation [SpecForge::Spec::Expectation] The expectation being evaluated
-        # @param example_group [RSpec::Core::ExampleGroup] The example group to update
+        # @param example_group [RSpec::ExampleGroups] The example group to update
         #
         def set_for_group(spec, expectation, example_group)
           metadata = {

--- a/spec/integration/spec_forge/forge_helper.rb
+++ b/spec/integration/spec_forge/forge_helper.rb
@@ -1,27 +1,81 @@
 # frozen_string_literal: true
 
 require_relative "../config/environment"
-# require "database_cleaner/active_record"
+require "database_cleaner/active_record"
 
 SpecForge.configure do |config|
   config.base_url = "http://localhost:3000"
 
-  # api_token = ApiToken.all.first.token
-  # config.headers = {
-  #   "Authorization" => "Bearer #{api_token}"
-  # }
+  # Optional: Use documentation formatter for clearer output with callbacks
+  config.rspec.formatter = :documentation
 
-  # config.specs.before(:suite) do
-  #   exception_tables = {except: %w[api_tokens]}
-  #   DatabaseCleaner.strategy = [:deletion, exception_tables]
-  #   DatabaseCleaner.clean_with(:deletion, exception_tables)
-  # end
+  # Configure DatabaseCleaner with RSpec hooks
+  exception_tables = {except: %w[api_tokens]}
 
-  # config.specs.around do |example|
-  #   DatabaseCleaner.cleaning do
-  #     example.run
-  #   end
-  # end
+  config.rspec.before(:suite) do
+    DatabaseCleaner.strategy = [:deletion, exception_tables]
+    DatabaseCleaner.clean_with(:deletion, exception_tables)
+    puts "\n🧪 TEST SUITE STARTED 🧪\n"
+  end
 
+  config.rspec.after(:suite) do
+    puts "\n🏁 TEST SUITE COMPLETED 🏁\n"
+  end
+
+  #============================================================
+  # CALLBACK DEFINITIONS
+  #============================================================
+
+  # File-level callbacks
+  #------------------------------------------------------------
+  config.define_callback :log_file_start do |context|
+    puts "\n📄 TESTING FILE: #{context.file_name}\n"
+  end
+
+  config.define_callback :log_file_end do |context|
+    puts "\n✅ COMPLETED FILE: #{context.file_name}\n"
+  end
+
+  # Expectation-level callbacks
+  #------------------------------------------------------------
+  config.define_callback :prepare_database_state do |context|
+    # Setup clean database state before each expectation
+    DatabaseCleaner.start
+
+    # If this wasn't a demo, we'd skip this print in production
+    puts "\n┌─ PREPARING DB FOR: #{context.expectation_name}"
+  end
+
+  config.define_callback :cleanup_database_state do |context|
+    # Clean up after each expectation
+    DatabaseCleaner.clean
+
+    puts "└─ CLEANED DB AFTER: #{context.expectation_name}\n"
+  end
+
+  # Logging callback with full context
+  #------------------------------------------------------------
+  config.define_callback :log_context_data do |context|
+    # Skip in real usage - this is just to demonstrate available data
+    if ENV["DEBUG_CALLBACKS"]
+      puts "  ┌─── CONTEXT DATA ───┐"
+      puts "  │ File: #{context.file_name}"
+      puts "  │ Spec: #{context.spec_name}"
+      puts "  │ Test: #{context.expectation_name}"
+      puts "  │ URL: #{context.request.url}" if context.respond_to?(:request)
+      puts "  └───────────────────┘"
+    end
+  end
+
+  config.define_callback :log_test_result do |context|
+    # This would be where you could log test results,
+    # save screenshots, or perform other post-test actions
+    if ENV["DEBUG_CALLBACKS"]
+      status = context.response&.status
+      puts "  RESULT: #{status || "N/A"}"
+    end
+  end
+
+  # Debugging support
   config.on_debug = -> { binding.pry } # standard:disable Lint/Debugger
 end

--- a/spec/integration/spec_forge/specs/01_basic_requests.yml
+++ b/spec/integration/spec_forge/specs/01_basic_requests.yml
@@ -1,3 +1,25 @@
+#
+# 01_basic_requests.yml
+#
+# This file demonstrates the basic HTTP request functionality in SpecForge.
+#
+# REQUEST OVERVIEW:
+# ------------------
+# SpecForge supports all standard HTTP methods and provides a clean syntax
+# for working with path parameters, query parameters, and request bodies.
+#
+# SUPPORTED HTTP METHODS:
+# - GET (default when no method specified)
+# - POST
+# - PUT
+# - PATCH
+# - DELETE
+#
+# PATH PARAMETERS:
+# Path parameters can be defined using either {placeholder} or :placeholder syntax
+# and are populated from the query section.
+#
+
 # Basic GET with no parameters
 get_status:
   path: /status

--- a/spec/integration/spec_forge/specs/02_matchers.yml
+++ b/spec/integration/spec_forge/specs/02_matchers.yml
@@ -1,3 +1,26 @@
+#
+# 02_matchers.yml
+#
+# This file demonstrates the powerful matcher system in SpecForge.
+#
+# MATCHER OVERVIEW:
+# ----------------
+# SpecForge leverages RSpec's matcher system with a clean YAML syntax.
+# Matchers allow flexible validation of responses beyond exact matching.
+#
+# MATCHER NAMESPACES:
+# - be.*          - Predicate and comparison matchers
+#                   Examples: be.true, be.nil, be.greater_than: 5
+#
+# - kind_of.*     - Type checking matchers
+#                   Examples: kind_of.string, kind_of.integer, kind_of.array
+#
+# - matcher.*     - Additional matchers for complex validation
+#                   Examples: matcher.include, matcher.all, matcher.have_size
+#
+# - Regular expressions can be used directly: /pattern/
+#
+
 # PART 1: BASIC MATCHERS
 basic_matchers:
   path: /data/types

--- a/spec/integration/spec_forge/specs/03_variables.yml
+++ b/spec/integration/spec_forge/specs/03_variables.yml
@@ -1,3 +1,21 @@
+#
+# 03_variables.yml
+#
+# This file demonstrates the variable system in SpecForge.
+#
+# VARIABLE OVERVIEW:
+# -----------------
+# Variables allow you to define and reuse values throughout your specs.
+# They can be defined at both the spec and expectation level, with expectation-level
+# variables taking precedence over spec-level ones with the same name.
+#
+# VARIABLE FEATURES:
+# - Variable references use the 'variables.' prefix
+# - Variables can reference other variables
+# - Variables can be chained to access nested properties
+# - Variables can be used in path parameters, query params, request bodies, and expectations
+#
+
 # SECTION 1: BASIC VARIABLE USAGE
 basic_variables:
   path: /data/types

--- a/spec/integration/spec_forge/specs/04_dynamic_data.yml
+++ b/spec/integration/spec_forge/specs/04_dynamic_data.yml
@@ -1,3 +1,25 @@
+#
+# 04_dynamic_data.yml
+#
+# This file demonstrates the dynamic data generation capabilities in SpecForge.
+#
+# DYNAMIC DATA OVERVIEW:
+# ---------------------
+# SpecForge integrates with Faker and FactoryBot to provide powerful dynamic
+# data generation for tests without writing Ruby code.
+#
+# FAKER INTEGRATION:
+# - Access any Faker method with the 'faker.' prefix
+# - Supports method chaining: faker.internet.email.downcase
+# - Supports arguments: faker.number.between: {from: 1, to: 10}
+#
+# FACTORY INTEGRATION:
+# - Access factories with the 'factories.' prefix
+# - Reference factory attributes with dot notation: factories.user.name
+# - Customize factories: factories.user: {attributes: {name: "Custom"}}
+# - Control factory strategy: factories.user: {strategy: build}
+#
+
 # SECTION 1: BASIC FAKER USAGE
 basic_faker:
   path: /status

--- a/spec/integration/spec_forge/specs/05_callbacks.yml
+++ b/spec/integration/spec_forge/specs/05_callbacks.yml
@@ -1,0 +1,65 @@
+#
+# 05_callbacks.yml
+#
+# This file demonstrates the callback functionality in SpecForge.
+#
+# CALLBACK OVERVIEW:
+# ------------------
+# Callbacks are defined globally and trigger at specific points in the test lifecycle:
+#
+# - before_file/after_file: Run once at the beginning/end of processing this file
+#   Example use: Setting up test fixtures, logging test suite progress
+#
+# - before_spec/after_spec: Run once at the beginning/end of each spec
+#   Example use: Setting up spec-specific data, tracking spec runtime
+#
+# - before_each/after_each: Run before/after each expectation
+#   (shorthand aliases: 'before'/'after')
+#   Example use: Database setup/cleanup, request/response logging
+#
+# Callbacks can accept a context parameter with data relevant to their scope:
+#   - File callbacks: access forge, file_path, file_name
+#   - Spec callbacks: all file data + spec, spec_name, variables
+#   - Expectation callbacks: all spec data + expectation, expectation_name,
+#                            request, response, example_group, example
+#
+
+global:
+  # Define callbacks that apply to all tests in this file
+  callbacks:
+  # Track file progress
+  - before_file: log_file_start
+    after_file: log_file_end
+
+  # Database management - runs before/after each expectation
+  - before: prepare_database_state
+    after: cleanup_database_state
+
+  # Logging with access to test context
+  - before_each: log_context_data
+    after_each: log_test_result
+
+# Simple test to demonstrate callbacks in action
+user_management:
+  path: /users
+  variables:
+    user_name: "Callback Demo User"
+    user_email: "callback-demo@example.com"
+  expectations:
+  - name: "Creating a user"
+    method: post
+    body:
+      name: variables.user_name
+      email: variables.user_email
+    expect:
+      status: 201
+      json:
+        user:
+          name: variables.user_name
+
+  - name: "Retrieving users - but no users exist"
+    expect:
+      status: 200
+      json:
+        total: 0
+        users: []

--- a/spec/lib/spec_forge/attribute_spec.rb
+++ b/spec/lib/spec_forge/attribute_spec.rb
@@ -269,6 +269,24 @@ RSpec.describe SpecForge::Attribute do
       end
     end
 
+    context "when the resolved value is an empty ArrayLike" do
+      let(:input) { [] }
+
+      it "is expected to resolve into an 'eq' matcher" do
+        expect(resolved_matcher).to be_kind_of(matchers::Eq)
+        expect(resolved_matcher.expected).to eq([])
+      end
+    end
+
+    context "when the resolved value is an empty HashLike" do
+      let(:input) { {} }
+
+      it "is expected to resolve into an 'eq' matcher" do
+        expect(resolved_matcher).to be_kind_of(matchers::Eq)
+        expect(resolved_matcher.expected).to eq({})
+      end
+    end
+
     context "when the resolved value is Attribute::Matcher" do
       let(:input) { "kind_of.array" }
 

--- a/spec/lib/spec_forge/callbacks_spec.rb
+++ b/spec/lib/spec_forge/callbacks_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe SpecForge::Callbacks do
     end
   end
 
-  describe "#run_callback" do
-    subject(:result) { described_class.run_callback(name, 1) }
+  describe "#run" do
+    subject(:result) { described_class.run(name, 1) }
 
     context "when the callback is defined" do
       it "is expected to call" do
@@ -81,7 +81,7 @@ RSpec.describe SpecForge::Callbacks do
 
     context "when the callback is not defined" do
       it do
-        expect { described_class.run_callback(:noop, nil) }.to raise_error(ArgumentError)
+        expect { described_class.run(:noop, nil) }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/lib/spec_forge/callbacks_spec.rb
+++ b/spec/lib/spec_forge/callbacks_spec.rb
@@ -69,13 +69,20 @@ RSpec.describe SpecForge::Callbacks do
     end
   end
 
-  describe "#run_callbacks" do
+  describe "#run_callback" do
+    subject(:result) { described_class.run_callback(name, 1) }
+
     context "when the callback is defined" do
-      it "is expected to call"
+      it "is expected to call" do
+        described_class.register(name) { |a| a }
+        expect(result).to eq(1)
+      end
     end
 
     context "when the callback is not defined" do
-      it {}
+      it do
+        expect { described_class.run_callback(:noop, nil) }.to raise_error(ArgumentError)
+      end
     end
   end
 end

--- a/spec/lib/spec_forge/callbacks_spec.rb
+++ b/spec/lib/spec_forge/callbacks_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe SpecForge::Callbacks do
+  describe ".register" do
+    let(:name) { "testing" }
+
+    subject(:registered) { described_class.register(name) {} }
+
+    context "when the callback has not been registered" do
+      it "is expected to store the block" do
+        expect(registered).to be_kind_of(Proc)
+      end
+    end
+
+    context "when the callback has already been registered" do
+      it "is expected to print a warning" do
+        registered
+
+        expect {
+          described_class.register(name) {}
+        }.to output(
+          "Callback #{name.in_quotes} is already registered. It will be overwritten\n"
+        ).to_stderr
+      end
+    end
+
+    context "when the callback is not provided a block" do
+      it do
+        expect {
+          described_class.register(name)
+        }.to raise_error(ArgumentError, "A block must be provided")
+      end
+    end
+  end
+end

--- a/spec/lib/spec_forge/callbacks_spec.rb
+++ b/spec/lib/spec_forge/callbacks_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe SpecForge::Callbacks do
-  describe ".register" do
-    let(:name) { "testing" }
+  let(:name) { "testing" }
 
+  describe ".register" do
     subject(:registered) { described_class.register(name) {} }
 
     context "when the callback has not been registered" do
@@ -30,6 +30,52 @@ RSpec.describe SpecForge::Callbacks do
           described_class.register(name)
         }.to raise_error(ArgumentError, "A block must be provided")
       end
+    end
+  end
+
+  describe "#registered?" do
+    subject(:registered?) { described_class.registered?(name) }
+
+    context "when the callback has been registered" do
+      before do
+        described_class.register(name) {}
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when the callback has not been registered" do
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe "#registered_names" do
+    subject(:registered_names) { described_class.registered_names }
+
+    context "when there are callbacks" do
+      before do
+        described_class.register(name) {}
+      end
+
+      it "is expected to return the names as an array" do
+        is_expected.to eq([name])
+      end
+    end
+
+    context "when there are no callbacks" do
+      it "is expected to return an empty array" do
+        is_expected.to eq([])
+      end
+    end
+  end
+
+  describe "#run_callbacks" do
+    context "when the callback is defined" do
+      it "is expected to call"
+    end
+
+    context "when the callback is not defined" do
+      it {}
     end
   end
 end

--- a/spec/lib/spec_forge/configuration_spec.rb
+++ b/spec/lib/spec_forge/configuration_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe SpecForge::Configuration do
+  subject(:configuration) { described_class.new }
+
   describe ".overlay_options" do
     let(:source) {}
     let(:overlay) {}
@@ -202,5 +204,27 @@ RSpec.describe SpecForge::Configuration do
         )
       end
     end
+  end
+
+  describe "#register_callback/#define_callback/#callback" do
+    it "is expected to responds to all three" do
+      is_expected.to respond_to(:register_callback)
+      is_expected.to respond_to(:define_callback)
+      is_expected.to respond_to(:callback)
+    end
+
+    it "is expected to register a callback" do
+      configuration.callback(:callback_one) {}
+      configuration.define_callback(:callback_two) {}
+      configuration.register_callback(:callback_three) {}
+
+      names = SpecForge::Callbacks.registered_names
+      expect(names).to contain_exactly("callback_one", "callback_two", "callback_three")
+    end
+  end
+
+  describe "#specs" do
+    it { is_expected.to respond_to(:specs) }
+    it { expect(configuration.specs).to be_kind_of(RSpec::Core::Configuration) }
   end
 end

--- a/spec/lib/spec_forge/context/callbacks_spec.rb
+++ b/spec/lib/spec_forge/context/callbacks_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe SpecForge::Context::Callbacks do
+  let(:callbacks) { [] }
+
+  subject(:context) { described_class.new(callbacks) }
+
   describe "#initialize" do
-    let(:callbacks) { [] }
-
-    subject(:context) { described_class.new(callbacks) }
-
     context "when callbacks are provided" do
       let(:callbacks) do
         [
@@ -51,6 +51,29 @@ RSpec.describe SpecForge::Context::Callbacks do
           is_expected.to eq({})
         end
       end
+    end
+  end
+
+  describe "#run" do
+    let(:callbacks) do
+      [
+        {before_each: "callback_1"},
+        {before_each: "callback_2"}
+      ]
+    end
+
+    let(:result) { [] }
+
+    subject(:runner) { context.run(:before_each, context_key: 1) }
+
+    before do
+      SpecForge::Callbacks.register("callback_1") { |context| result << context.context_key }
+      SpecForge::Callbacks.register("callback_2") { |context| result << (context.context_key + 1) }
+    end
+
+    it "is expected to trigger the callbacks" do
+      runner
+      expect(result).to contain_exactly(1, 2)
     end
   end
 end

--- a/spec/lib/spec_forge/context/callbacks_spec.rb
+++ b/spec/lib/spec_forge/context/callbacks_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.describe SpecForge::Context::Callbacks do
+  describe "#initialize" do
+    let(:callbacks) { [] }
+
+    subject(:context) { described_class.new(callbacks) }
+
+    context "when callbacks are provided" do
+      let(:callbacks) do
+        [
+          {before_each: "callback_1", after_each: "callback_2"},
+          {before_spec: "callback_3", after_file: "callback_4"}
+        ]
+      end
+
+      subject(:groups) { context.to_h }
+
+      context "and there are no duplicates" do
+        it "is expected to group them by their hook" do
+          is_expected.to match(
+            before_each: Set["callback_1"],
+            after_each: Set["callback_2"],
+            before_spec: Set["callback_3"],
+            after_file: Set["callback_4"]
+          )
+        end
+      end
+
+      context "and there are duplicates" do
+        before do
+          callbacks << {before_each: "callback_1"}
+        end
+
+        it "is expected to ignore the duplicate" do
+          is_expected.to match(
+            before_each: Set["callback_1"],
+            after_each: Set["callback_2"],
+            before_spec: Set["callback_3"],
+            after_file: Set["callback_4"]
+          )
+        end
+      end
+
+      context "and there are nil and empty strings" do
+        let(:callbacks) do
+          [{before_each: "", after_each: nil}]
+        end
+
+        it "is expected to ignore them" do
+          is_expected.to eq({})
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/spec_forge/normalizer/global_context_spec.rb
+++ b/spec/lib/spec_forge/normalizer/global_context_spec.rb
@@ -83,5 +83,20 @@ RSpec.describe SpecForge::Normalizer do
         )
       end
     end
+
+    context "when a callback name is not a String" do
+      before do
+        global[:callbacks] = [
+          {before: 1}
+        ]
+      end
+
+      it do
+        expect { normalized }.to raise_error(
+          SpecForge::Error::InvalidStructureError,
+          %{Expected String or NilClass, got Integer for "before_each" (aliases "before") in index 0 of "callbacks" in global context}
+        )
+      end
+    end
   end
 end

--- a/spec/lib/spec_forge/normalizer/global_context_spec.rb
+++ b/spec/lib/spec_forge/normalizer/global_context_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe SpecForge::Normalizer do
 
     subject(:normalized) { described_class.normalize_global_context!(global) }
 
+    before do
+      SpecForge::Callbacks.register("test_callback") {}
+    end
+
     it "is expected to normalize normally" do
       expect(normalized).to include(
         variables: {
@@ -95,6 +99,21 @@ RSpec.describe SpecForge::Normalizer do
         expect { normalized }.to raise_error(
           SpecForge::Error::InvalidStructureError,
           %{Expected String or NilClass, got Integer for "before_each" (aliases "before") in index 0 of "callbacks" in global context}
+        )
+      end
+    end
+
+    context "when a callback name is not defined" do
+      before do
+        global[:callbacks] = [
+          {before: "Not defined, yo"}
+        ]
+      end
+
+      it do
+        expect { normalized }.to raise_error(
+          SpecForge::Error::InvalidStructureError,
+          %(The callback "Not defined, yo" was referenced but hasn't been defined.\nAvailable callbacks are: "test_callback")
         )
       end
     end

--- a/spec/lib/spec_forge/normalizer/global_context_spec.rb
+++ b/spec/lib/spec_forge/normalizer/global_context_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe SpecForge::Normalizer do
         variables: {
           var_1: true,
           var_2: "faker.string.random"
-        }
+        },
+        callbacks: [
+          {before: "test_callback"}
+        ]
       }
     end
 
@@ -41,6 +44,42 @@ RSpec.describe SpecForge::Normalizer do
         expect { normalized }.to raise_error(
           SpecForge::Error::InvalidStructureError,
           "Expected Hash, got Integer for \"variables\" in global context"
+        )
+      end
+    end
+
+    context "when 'callbacks' is nil" do
+      before do
+        global[:callbacks] = nil
+      end
+
+      it "is expected to default it to an empty hash" do
+        expect(normalized[:callbacks]).to eq([])
+      end
+    end
+
+    context "when 'callbacks' is not a Array" do
+      before do
+        global[:callbacks] = 1
+      end
+
+      it do
+        expect { normalized }.to raise_error(
+          SpecForge::Error::InvalidStructureError,
+          "Expected Array, got Integer for \"callbacks\" in global context"
+        )
+      end
+    end
+
+    context "when 'callbacks' is not an array of objects" do
+      before do
+        global[:callbacks] = ["test_callback"]
+      end
+
+      it do
+        expect { normalized }.to raise_error(
+          SpecForge::Error::InvalidStructureError,
+          "Expected Hash, got String for index 0 of \"callbacks\" in global context"
         )
       end
     end

--- a/spec/lib/spec_forge/normalizer_spec.rb
+++ b/spec/lib/spec_forge/normalizer_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe SpecForge::Normalizer do
 
         expect(error).to be_kind_of(SpecForge::Error::InvalidTypeError)
         expect(error.message).to eq(
-          "Expected String, got Integer for \"key_3\" in normalizer"
+          "Expected String, got Integer for \"key_3\" in \"key_2\" in \"nested\" in normalizer"
         )
       end
     end

--- a/spec/lib/spec_forge/runner/callbacks_spec.rb
+++ b/spec/lib/spec_forge/runner/callbacks_spec.rb
@@ -1,6 +1,21 @@
 # frozen_string_literal: true
 
 RSpec.describe SpecForge::Runner::Callbacks do
+  let(:global) { {} }
+  let(:metadata) { {} }
+  let(:specs) { [] }
+
+  let(:forge) { Generator.forge(global:, metadata:, specs:) }
+
+  # These are not called directly by this file. They'll be called as part of the lifecycle
+  let(:request) do
+    SpecForge::HTTP::Request.new(
+      base_url: "", url: "", http_verb: "GET", headers: {}, query: {}, body: {}
+    )
+  end
+
+  let(:response) { Faraday::Response.new }
+
   subject(:callbacks) { described_class }
 
   describe "The callback lifecycle" do
@@ -30,13 +45,6 @@ RSpec.describe SpecForge::Runner::Callbacks do
         {} # Empty spec, needed just to test it doing a reset
       ]
     end
-
-    let(:forge) { Generator.forge(global:, metadata: {}, specs:) }
-
-    # These are not called directly by this file. They'll be called on this example
-    # during the lifecycle
-    let(:request) { {query: {}} }
-    let(:response) { {headers: {}, status: {}, body: {}}.to_istruct }
 
     subject(:context) { SpecForge.context }
 
@@ -106,9 +114,9 @@ RSpec.describe SpecForge::Runner::Callbacks do
       expect(context.store.size).to eq(1)
       expect(context.store["stored_as_file"]).to have_attributes(
         scope: :file,
-        request:,
+        request: include(:base_url, :url, :headers, :body, :http_verb, :query),
         variables: match(var_1: be_kind_of(String), var_2: [2]),
-        response: response.to_h
+        response: include(:headers, :status, :body)
       )
 
       ##########################################################################
@@ -135,9 +143,9 @@ RSpec.describe SpecForge::Runner::Callbacks do
       expect(context.store.size).to eq(2)
       expect(context.store["stored_as_spec"]).to have_attributes(
         scope: :spec,
-        request:,
+        request: include(:base_url, :url, :headers, :body, :http_verb, :query),
         variables: match(var_1: be_kind_of(Regexp), var_2: 1),
-        response: response.to_h
+        response: include(:headers, :status, :body)
       )
 
       ##########################################################################
@@ -179,6 +187,164 @@ RSpec.describe SpecForge::Runner::Callbacks do
       expect(context.store.size).to eq(1) # One expectation was stored at the file level
 
       # And we're done!
+    end
+  end
+
+  # {before_spec: "cb_before_spec", after_spec: "cb_after_spec"},
+  # {before_each: "cb_before_each", after_each: "cb_after_each"},
+  # {around_each: "cb_around_each"}
+  describe "The user defined callback lifecycle" do
+    let(:specs) do
+      [{
+        name: "spec_name",
+        variables: {var_1: true},
+        expectations: [{}]
+      }]
+    end
+
+    let(:metadata) do
+      {
+        file_path: "test/path/test.yml",
+        file_name: "test"
+      }
+    end
+
+    let(:results) { [] }
+    let(:results_proc) { ->(c) { results << c } }
+
+    context "when 'before_file'/'after_file' is called" do
+      let(:global) do
+        {
+          callbacks: [
+            {before_file: "cb_before_file", after_file: "cb_after_file"}
+          ]
+        }
+      end
+
+      let(:expected) do
+        {
+          forge: be_kind_of(SpecForge::Forge),
+          file_path: "test/path/test.yml",
+          file_name: "test"
+        }
+      end
+
+      before do
+        SpecForge::Callbacks.register(:cb_before_file, &results_proc)
+        SpecForge::Callbacks.register(:cb_after_file, &results_proc)
+      end
+
+      it "is expected to execute the callback with context data" do
+        callbacks.before_file(forge)
+        callbacks.after_file(forge)
+
+        # before_file
+        expect(results.first).to have_attributes(**expected)
+
+        # after_file
+        expect(results.second).to have_attributes(**expected)
+      end
+    end
+
+    context "when 'before_spec'/'after_spec' is called" do
+      let(:global) do
+        {
+          callbacks: [
+            {before_spec: "cb_before_spec", after_spec: "cb_after_spec"}
+          ]
+        }
+      end
+
+      let(:expected) do
+        {
+          forge: be_kind_of(SpecForge::Forge),
+          file_path: "test/path/test.yml",
+          file_name: "test",
+          spec: be_kind_of(SpecForge::Spec),
+          spec_name: "spec_name",
+          variables: have_attributes(var_1: true)
+        }
+      end
+
+      before do
+        SpecForge::Callbacks.register(:cb_before_spec, &results_proc)
+        SpecForge::Callbacks.register(:cb_after_spec, &results_proc)
+
+        # Needs to be called for the global context to be loaded
+        callbacks.before_file(forge)
+      end
+
+      it "is expected to execute the callback with context data" do
+        callbacks.before_spec(forge, forge.specs.first)
+        callbacks.after_spec(forge, forge.specs.first)
+
+        # before_spec
+        expect(results.first).to have_attributes(**expected)
+
+        # after_spec
+        expect(results.second).to have_attributes(**expected)
+      end
+    end
+
+    context "when 'before_each'/'after_each' is called" do
+      let(:global) do
+        {
+          callbacks: [
+            {before_each: "cb_before_each", after_each: "cb_after_each"}
+          ]
+        }
+      end
+
+      let(:expected) do
+        {
+          forge: be_kind_of(SpecForge::Forge),
+          file_path: "test/path/test.yml",
+          file_name: "test",
+          spec: be_kind_of(SpecForge::Spec),
+          spec_name: "spec_name",
+          variables: have_attributes(var_1: true),
+          expectation: be_kind_of(SpecForge::Spec::Expectation),
+          expectation_name: be_kind_of(String),
+          request: be_kind_of(SpecForge::HTTP::Request),
+          example_group: be_kind_of(RSpec::Core::ExampleGroup),
+          example: be_kind_of(RSpec::Core::Example)
+        }
+      end
+
+      before do
+        SpecForge::Callbacks.register(:cb_before_each, &results_proc)
+        SpecForge::Callbacks.register(:cb_after_each, &results_proc)
+
+        # Needs to be called for the global context to be loaded
+        callbacks.before_file(forge)
+        callbacks.before_spec(forge, forge.specs.first)
+      end
+
+      it "is expected to execute the callback with context data" do
+        spec = forge.specs.first
+
+        args = [
+          forge,
+          spec,
+          spec.expectations.first,
+          self,
+          RSpec.current_example
+        ]
+
+        # before_each
+        expect(self).to receive(:response).and_return(nil)
+        expected[:response] = be(nil)
+
+        callbacks.before_expectation(*args)
+        expect(results.first).to have_attributes(**expected)
+
+        # after_each
+        expect(self).to receive(:response).and_call_original
+        expected[:response] = be_kind_of(Faraday::Response)
+
+        callbacks.after_expectation(*args)
+        expect(results.second).to have_attributes(**expected)
+      end
     end
   end
 end

--- a/spec/lib/spec_forge/runner/callbacks_spec.rb
+++ b/spec/lib/spec_forge/runner/callbacks_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe SpecForge::Runner::Callbacks do
       ##########################################################################
       ## before_expectation, expectation 0
       expectation = spec.expectations.first
-      callbacks.before_expectation(forge, spec, expectation)
+      callbacks.before_expectation(forge, spec, expectation, self, RSpec.current_example)
 
       # Check our test's metadata, since it modifies it lol
       expect(RSpec.current_example.metadata[:location]).to start_with("test/path")
@@ -100,7 +100,7 @@ RSpec.describe SpecForge::Runner::Callbacks do
       ## after_expectation, expectation 0
 
       # Pass in this example so it can access request and response variables
-      callbacks.after_expectation(forge, spec, expectation, self)
+      callbacks.after_expectation(forge, spec, expectation, self, RSpec.current_example)
 
       # This expectation is stored at the file level
       expect(context.store.size).to eq(1)
@@ -114,7 +114,7 @@ RSpec.describe SpecForge::Runner::Callbacks do
       ##########################################################################
       ## before_expectation, expectation 1
       expectation = spec.expectations.second
-      callbacks.before_expectation(forge, spec, expectation)
+      callbacks.before_expectation(forge, spec, expectation, self, RSpec.current_example)
 
       # Now we have overlaid variables
       variables = context.variables.resolved
@@ -129,7 +129,7 @@ RSpec.describe SpecForge::Runner::Callbacks do
       ## after_expectation, expectation 1
 
       # Pass in this example so it can access request and response variables
-      callbacks.after_expectation(forge, spec, expectation, self)
+      callbacks.after_expectation(forge, spec, expectation, self, RSpec.current_example)
 
       # This expectation is stored at the spec level
       expect(context.store.size).to eq(2)
@@ -143,7 +143,7 @@ RSpec.describe SpecForge::Runner::Callbacks do
       ##########################################################################
       ## before_expectation, expectation 2
       expectation = spec.expectations.third
-      callbacks.before_expectation(forge, spec, expectation)
+      callbacks.before_expectation(forge, spec, expectation, self, RSpec.current_example)
 
       # Now we have a combination of variables
       variables = context.variables.resolved
@@ -163,7 +163,7 @@ RSpec.describe SpecForge::Runner::Callbacks do
       ## after_expectation, expectation 2
 
       # Pass in this example so it can access request and response variables
-      callbacks.after_expectation(forge, spec, expectation, self)
+      callbacks.after_expectation(forge, spec, expectation, self, RSpec.current_example)
 
       # This expectation is not stored
       expect(context.store.size).to eq(2)

--- a/spec/lib/spec_forge/runner/callbacks_spec.rb
+++ b/spec/lib/spec_forge/runner/callbacks_spec.rb
@@ -223,6 +223,7 @@ RSpec.describe SpecForge::Runner::Callbacks do
 
       let(:expected) do
         {
+          callback_scope: "file",
           forge: be_kind_of(SpecForge::Forge),
           file_path: "test/path/test.yml",
           file_name: "test"
@@ -235,13 +236,16 @@ RSpec.describe SpecForge::Runner::Callbacks do
       end
 
       it "is expected to execute the callback with context data" do
-        callbacks.before_file(forge)
-        callbacks.after_file(forge)
-
         # before_file
+        expected.merge!(callback_type: "before_file", callback_timing: "before")
+
+        callbacks.before_file(forge)
         expect(results.first).to have_attributes(**expected)
 
         # after_file
+        expected.merge!(callback_type: "after_file", callback_timing: "after")
+
+        callbacks.after_file(forge)
         expect(results.second).to have_attributes(**expected)
       end
     end
@@ -257,6 +261,7 @@ RSpec.describe SpecForge::Runner::Callbacks do
 
       let(:expected) do
         {
+          callback_scope: "spec",
           forge: be_kind_of(SpecForge::Forge),
           file_path: "test/path/test.yml",
           file_name: "test",
@@ -275,13 +280,16 @@ RSpec.describe SpecForge::Runner::Callbacks do
       end
 
       it "is expected to execute the callback with context data" do
-        callbacks.before_spec(forge, forge.specs.first)
-        callbacks.after_spec(forge, forge.specs.first)
-
         # before_spec
+        expected.merge!(callback_type: "before_spec", callback_timing: "before")
+
+        callbacks.before_spec(forge, forge.specs.first)
         expect(results.first).to have_attributes(**expected)
 
         # after_spec
+        expected.merge!(callback_type: "after_spec", callback_timing: "after")
+
+        callbacks.after_spec(forge, forge.specs.first)
         expect(results.second).to have_attributes(**expected)
       end
     end
@@ -297,6 +305,7 @@ RSpec.describe SpecForge::Runner::Callbacks do
 
       let(:expected) do
         {
+          callback_scope: "each",
           forge: be_kind_of(SpecForge::Forge),
           file_path: "test/path/test.yml",
           file_name: "test",
@@ -333,14 +342,22 @@ RSpec.describe SpecForge::Runner::Callbacks do
 
         # before_each
         expect(self).to receive(:response).and_return(nil)
-        expected[:response] = be(nil)
+        expected.merge!(
+          response: be(nil),
+          callback_type: "before_each",
+          callback_timing: "before"
+        )
 
         callbacks.before_expectation(*args)
         expect(results.first).to have_attributes(**expected)
 
         # after_each
         expect(self).to receive(:response).and_call_original
-        expected[:response] = be_kind_of(Faraday::Response)
+        expected.merge!(
+          response: be_kind_of(Faraday::Response),
+          callback_type: "after_each",
+          callback_timing: "after"
+        )
 
         callbacks.after_expectation(*args)
         expect(results.second).to have_attributes(**expected)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,9 @@ RSpec.configure do |config|
     # Reset the context
     SpecForge.instance_variable_set(:@context, nil)
 
+    # Reset the callbacks
+    SpecForge::Callbacks.instance.clear
+
     # Remove any factories that were registered
     FactoryBot::Internal.configuration.factories.clear
   end


### PR DESCRIPTION
## Description
This PR adds support for users to define and reference callbacks on a per file basis. Callbacks are defined during configuration, don't require commitment of when they are triggered ahead of time, and are provided a context specific object that changes depending on when the callback is triggered. 
```rb
SpecForge.configure do |config|
  config.define_callback :prepare_database do |context|
    DatabaseCleaner.start
  end
end 
```
Once a callback is defined, it can be used in a spec file under the `global` key:
```yaml
# specs/users.yml
global:
  callbacks:
  - before: prepare_database # alias for before_each
```
Other callbacks are before_file, before_spec, before_each, after_file, after_spec, and after_each.