### PR TITLE
feat - Add support for normalizing dynamic keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New YAML-based normalizer architecture with structure definitions in `lib/spec_forge/normalizers/`
 - Support for structure references with `reference:` keyword for composition
 - Dedicated validators module for reusable validation logic
+- Added wildcard key support to the Normalizer with `*` syntax
+  - Allows defining a catch-all schema for keys not explicitly defined in a structure
+    ```yaml
+    # Example structure definition
+    person:
+      type: hash
+      structure:
+        name:
+          type: string
+        age:
+          type: integer
+        "*": # Wildcard that catches all other keys
+          type: string
+    ```
 
 ### Changed
 - Completely refactored Normalizer class for improved maintainability

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742422364,
-        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Ruby 3.4.2 development environment";
+  description = "Ruby 3.2 development environment";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -20,7 +20,7 @@
       {
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
-            (ruby_3_4.override {
+            (ruby_3_2.override {
               jemallocSupport = true;
               docSupport = false;
             })

--- a/lib/spec_forge/normalizer.rb
+++ b/lib/spec_forge/normalizer.rb
@@ -282,63 +282,126 @@ module SpecForge
     end
 
     #
-    # Normalizes the input hash according to the structure definition
+    # Normalizes a hash according to the structure definition
     #
-    # @return [Array<Hash, Set>] Normalized hash and any errors
+    # Processes each key-value pair in the input hash according to the corresponding
+    # definition in the structure. Handles both explicitly defined keys and wildcard
+    # keys (specified with "*") that apply to any keys not otherwise defined.
+    #
+    # @return [Array<Hash, Set>] A two-element array containing:
+    #   1. The normalized hash with validated and transformed values
+    #   2. A set of any errors encountered during normalization
+    #
+    # @example Normalizing a hash with explicit definitions
+    #   structure = {name: {type: String}, age: {type: Integer}}
+    #   input = {name: "John", age: "25"}
+    #   normalize_hash # => [{name: "John", age: 25}, #<Set: {}>]
     #
     # @private
     #
     def normalize_hash
       output, errors = {}, Set.new
 
-      structure.each do |key, attribute|
-        has_default = attribute.key?(:default)
+      structure.each do |key, definition|
+        # Skip the wildcard key if it exists, handled below
+        next if key == :* || key == "*"
 
-        type_class = attribute[:type]
-        aliases = attribute[:aliases] || []
-        default = attribute[:default]
+        continue, value = normalize_attribute(key, definition, errors:)
+        next unless continue
 
-        # Required by default, unless explicitly set to false.
-        # Easier to think of it as !(required == false)
-        required = attribute[:required] != false
-
-        # Get the value
-        value = value_from_keys(input, [key.to_s] + aliases)
-
-        # Drop the key if needed
-        next if value.nil? && !has_default && !required
-
-        # Default the value if needed
-        value = default.dup if has_default && value.nil?
-
-        error_label = generate_error_label(key, aliases)
-
-        # Type + existence check
-        if !valid_class?(value, type_class, nilable: has_default)
-          if (line_number = input[:line_number])
-            error_label += " (line #{line_number})"
-          end
-
-          raise Error::InvalidTypeError.new(value, type_class, for: error_label)
-        end
-
-        # Call the validator if it has one
-        if (name = attribute[:validator]) && name.present?
-          Validators.call(name, value, label: error_label)
-        end
-
-        # Normalize any sub structures
-        if (substructure = attribute[:structure]) && substructure.present?
-          value = normalize_substructure(error_label, value, substructure, errors)
-        end
-
-        # Store the result
         output[key] = value
       rescue => e
         errors << e
       end
 
+      # A wildcard will normalize the rest of the keys in the input
+      wildcard_structure = structure[:*] || structure["*"]
+
+      if wildcard_structure.present?
+        # We need to determine which keys we need to check
+        structure_keys = (structure.keys + structure.values.key_map(:aliases))
+          .compact
+          .flatten
+          .map(&:to_sym)
+
+        # Once we have which keys the structure used, we can get the remaining keys
+        keys_to_normalize = (input.keys - structure_keys)
+
+        # They are checked against the wildcard's structure
+        keys_to_normalize.each do |key|
+          continue, value = normalize_attribute(key, wildcard_structure, errors:)
+          next unless continue
+
+          output[key] = value
+        rescue => e
+          errors << e
+        end
+      end
+
       [output, errors]
+    end
+
+    #
+    # Normalizes a single attribute according to its definition
+    #
+    # Validates the attribute against its type constraints, applies default values,
+    # runs custom validators, and recursively processes nested structures.
+    #
+    # @param key [Symbol, String] The attribute key to normalize
+    # @param definition [Hash] The definition specifying rules for the attribute
+    # @param errors [Set] A set to collect any errors encountered
+    #
+    # @return [Array<Boolean, Object>] A two-element array containing:
+    #   1. Boolean indicating if the attribute should be included in output
+    #   2. The normalized attribute value (if first element is true)
+    #
+    # @example Normalizing a simple attribute
+    #   key = :name
+    #   definition = {type: String, required: true}
+    #   normalize_attribute(key, definition, errors: Set.new)
+    #   # => [true, "John"]
+    #
+    # @private
+    #
+    def normalize_attribute(key, definition, errors:)
+      has_default = definition.key?(:default)
+
+      type_class = definition[:type]
+      aliases = definition[:aliases] || []
+      default = definition[:default]
+      required = definition[:required] != false
+
+      # Get the value
+      value = value_from_keys(input, [key.to_s] + aliases)
+
+      # Drop the key if needed
+      return [false] if value.nil? && !has_default && !required
+
+      # Default the value if needed
+      value = default.dup if has_default && value.nil?
+
+      error_label = generate_error_label(key, aliases)
+
+      # Type + existence check
+      if !valid_class?(value, type_class, nilable: has_default)
+        if (line_number = input[:line_number])
+          error_label += " (line #{line_number})"
+        end
+
+        raise Error::InvalidTypeError.new(value, type_class, for: error_label)
+      end
+
+      # Call the validator if it has one
+      if (name = definition[:validator]) && name.present?
+        Validators.call(name, value, label: error_label)
+      end
+
+      # Normalize any sub structures
+      if (substructure = definition[:structure]) && substructure.present?
+        value = normalize_substructure(error_label, value, substructure, errors)
+      end
+
+      [true, value]
     end
 
     #

--- a/spec/lib/spec_forge/normalizer_spec.rb
+++ b/spec/lib/spec_forge/normalizer_spec.rb
@@ -171,5 +171,64 @@ RSpec.describe SpecForge::Normalizer do
         expect(output).to eq(callbacks: [{before: "", and_everything_in_between: nil}])
       end
     end
+
+    context "when the structure uses '*'" do
+      context "and it is used as a root key" do
+        let(:input) do
+          {
+            specific: "",
+            all: 1,
+            other: 2,
+            keys: 3
+          }
+        end
+
+        let(:structure) do
+          {
+            :specific => {type: String},
+            :* => {type: Integer}
+          }
+        end
+
+        it "is expected to normalize any extra keys" do
+          output, errors = normalized
+          expect(errors).to be_empty
+
+          expect(output).to eq(input)
+        end
+      end
+
+      context "and it is used in a nested structure" do
+        let(:input) do
+          {
+            specific: {
+              any: "",
+              key: nil,
+              works: ""
+            }
+          }
+        end
+
+        let(:structure) do
+          {
+            specific: {
+              type: Hash,
+              structure: {
+                "*" => {type: String, default: ""}
+              }
+            }
+          }
+        end
+
+        it "is expected to normalize any extra keys" do
+          output, errors = normalized
+          expect(errors).to be_empty
+
+          expect(output).to eq(specific: {
+            any: "", key: "", works: ""
+          })
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of your changes -->

## Changelog

### Added
- Added support for normalizing dynamic keys using `"*"` as a key. 
```
required_key: string
"*": string # All other keys are checked against this structure
```

### Changed
- Move to using Ruby 3.2 in dev

### Removed
<!-- Now removed features -->
